### PR TITLE
Update docker-compose.yml to use env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       dockerfile: Dockerfile
       args:
         - VITE_OPENWEATHER_API_KEY=${VITE_OPENWEATHER_API_KEY}
-        - VITE_REACT_APP_API_URL=http://localhost:5000
+        - VITE_REACT_APP_API_URL=${VITE_REACT_APP_API_URL}
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
When using stacks pulling from the gh repo the env var is not respected 