### PR TITLE
Fix Apple CalDAV CDATA parsing (no events synced)

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,17 @@
+# Never copy host-built artifacts into the image.
+# esbuild/rollup (used by Vite) ship platform-specific native binaries, so a
+# macOS/Windows-built node_modules can break the Linux build. Always install
+# fresh inside the container.
+node_modules
+npm-debug.log
+
+# Build output is produced inside the image.
+dist
+
+# Misc
+.env
+**/.env
+coverage
+*.lcov
+.git
+.DS_Store

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,19 @@
+# Never copy host-built artifacts into the image.
+# better-sqlite3 is a native module and MUST be built inside the container;
+# copying a macOS/Windows-built node_modules causes "invalid ELF header".
+node_modules
+npm-debug.log
+
+# Local data / secrets — keep out of the image build context.
+data
+uploads
+widgets/*
+!widgets/.gitkeep
+
+# Misc
+.env
+**/.env
+coverage
+*.lcov
+.git
+.DS_Store

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "better-sqlite3": "^12.9.0",
     "cron-parser": "^5.5.0",
     "dotenv": "^17.4.2",
+    "fast-xml-parser": "5.9.3",
     "fastify": "^5.8.5",
     "ical-generator": "^10.2.0",
     "ical.js": "^2.2.1",

--- a/server/services/appleCalDAV.js
+++ b/server/services/appleCalDAV.js
@@ -1,11 +1,160 @@
 const axios = require('axios');
 const ICAL = require('ical.js');
+const { XMLParser } = require('fast-xml-parser');
 
 const CALDAV_BASE = 'https://caldav.icloud.com';
+
+// CalDAV responses are WebDAV "multistatus" XML envelopes whose <calendar-data>
+// elements contain an iCalendar (ICS) text payload. We use a real XML parser for
+// the envelope (it transparently handles CDATA, XML entities, and namespaces) and
+// hand the extracted ICS text to ical.js, which is responsible for parsing the
+// iCalendar payload itself.
+const xmlParser = new XMLParser({
+  removeNSPrefix: true,   // collapse d:/c:/cs:/ical: prefixes
+  ignoreAttributes: false, // need attributes (e.g. comp[name="VEVENT"])
+  attributeNamePrefix: '@_',
+  parseTagValue: false,    // keep text as strings (colors, ctags, hrefs)
+  trimValues: true,
+});
 
 function buildAuthHeader(appleId, appPassword) {
   return 'Basic ' + Buffer.from(`${appleId}:${appPassword}`).toString('base64');
 }
+
+// ---------------------------------------------------------------------------
+// XML helpers (pure, exported for testing)
+// ---------------------------------------------------------------------------
+
+function asArray(value) {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+// Resolve the text content of a parsed node, whether it is a bare string or an
+// object carrying attributes alongside a #text value (CDATA included).
+function nodeText(node) {
+  if (node === undefined || node === null) return null;
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number' || typeof node === 'boolean') return String(node);
+  if (typeof node === 'object' && '#text' in node) {
+    const text = node['#text'];
+    return text === undefined || text === null ? null : String(text);
+  }
+  return null;
+}
+
+// Find a prop value across all <propstat> blocks of a <response> (a response can
+// carry multiple propstats, e.g. one HTTP 200 and one HTTP 404).
+function findProp(response, key) {
+  for (const propstat of asArray(response && response.propstat)) {
+    const prop = propstat && propstat.prop;
+    if (prop && prop[key] !== undefined) return prop[key];
+  }
+  return undefined;
+}
+
+function absolutizeUrl(href) {
+  const value = (href || '').trim();
+  if (!value) return null;
+  return value.startsWith('http') ? value : `${CALDAV_BASE}${value}`;
+}
+
+function parseMultistatusResponses(xmlBody) {
+  const doc = xmlParser.parse(xmlBody);
+  return asArray(doc && doc.multistatus && doc.multistatus.response);
+}
+
+// Extract the current-user-principal URL from a PROPFIND response body.
+function parsePrincipalUrl(xmlBody) {
+  const responses = parseMultistatusResponses(xmlBody);
+  for (const response of responses) {
+    const cup = findProp(response, 'current-user-principal');
+    if (cup) {
+      const url = absolutizeUrl(nodeText(cup.href) ?? nodeText(cup));
+      if (url) return url;
+    }
+  }
+  // Fallback: first response-level href.
+  for (const response of responses) {
+    const url = absolutizeUrl(nodeText(response.href));
+    if (url) return url;
+  }
+  return null;
+}
+
+// Extract the calendar-home-set URL from a PROPFIND response body.
+function parseCalendarHomeUrl(xmlBody) {
+  const responses = parseMultistatusResponses(xmlBody);
+  for (const response of responses) {
+    const home = findProp(response, 'calendar-home-set');
+    if (home) {
+      const url = absolutizeUrl(nodeText(home.href) ?? nodeText(home));
+      if (url) return url;
+    }
+  }
+  return null;
+}
+
+// Extract VEVENT-capable calendars from a Depth:1 PROPFIND response body.
+function parseCalendars(xmlBody) {
+  const calendars = [];
+
+  for (const response of parseMultistatusResponses(xmlBody)) {
+    const href = nodeText(response.href);
+    if (!href) continue;
+
+    // Must be a calendar collection (resourcetype contains <calendar/>).
+    const resourcetype = findProp(response, 'resourcetype');
+    const isCalendar = !!resourcetype && typeof resourcetype === 'object' && 'calendar' in resourcetype;
+    if (!isCalendar) continue;
+
+    // If the server advertises supported components, require VEVENT support so
+    // we skip task/reminder-only collections.
+    const compSet = findProp(response, 'supported-calendar-component-set');
+    const comps = compSet ? asArray(compSet.comp) : [];
+    if (comps.length > 0) {
+      const supportsVevent = comps.some(
+        (comp) => String(comp && comp['@_name'] ? comp['@_name'] : '').toUpperCase() === 'VEVENT'
+      );
+      if (!supportsVevent) continue;
+    }
+
+    const name = nodeText(findProp(response, 'displayname')) || 'Calendar';
+    let color = nodeText(findProp(response, 'calendar-color'));
+    // Apple returns colors like #RRGGBBAA; normalize to #RRGGBB.
+    if (color && color.length === 9 && color.startsWith('#')) {
+      color = color.slice(0, 7);
+    }
+
+    const calUrl = absolutizeUrl(href);
+    calendars.push({ id: calUrl, name, color: color || '#3d7ab5', url: calUrl });
+  }
+
+  return calendars;
+}
+
+// Extract the raw ICS payload strings from a calendar REPORT response body.
+// The XML parser already unwraps CDATA and decodes XML entities, so the returned
+// strings start at "BEGIN:VCALENDAR" and are ready for ICAL.parse().
+function extractIcsPayloads(xmlBody) {
+  const payloads = [];
+
+  for (const response of parseMultistatusResponses(xmlBody)) {
+    const ics = nodeText(findProp(response, 'calendar-data'));
+    if (!ics) continue;
+
+    const trimmed = ics.trim();
+    if (trimmed.includes('BEGIN:VCALENDAR')) {
+      payloads.push(trimmed);
+    }
+  }
+
+  return payloads;
+}
+
+// ---------------------------------------------------------------------------
+// CalDAV HTTP flows
+// ---------------------------------------------------------------------------
 
 // Discover the user's personal CalDAV principal URL via PROPFIND
 async function discoverPrincipalUrl(appleId, appPassword) {
@@ -31,19 +180,8 @@ async function discoverPrincipalUrl(appleId, appPassword) {
   });
 
   if (response.status === 207 || response.status === 200) {
-    const body = response.data;
-    const hrefMatch = body.match(/<[^>]*:?href[^>]*>(https?:\/\/[^<]+)<\/[^>]*:?href>/i)
-      || body.match(/<[^>]*:?current-user-principal[^>]*>[\s\S]*?<[^>]*:?href[^>]*>([^<]+)<\/[^>]*:?href>/i);
-    if (hrefMatch) {
-      const href = hrefMatch[1].trim();
-      return href.startsWith('http') ? href : `${CALDAV_BASE}${href}`;
-    }
-    // Try to extract any href path
-    const pathMatch = body.match(/<[^>]*:?href[^>]*>([^<]+)<\/[^>]*:?href>/i);
-    if (pathMatch) {
-      const path = pathMatch[1].trim();
-      return path.startsWith('http') ? path : `${CALDAV_BASE}${path}`;
-    }
+    const principalUrl = parsePrincipalUrl(response.data);
+    if (principalUrl) return principalUrl;
   }
 
   throw new Error(`iCloud principal discovery failed (HTTP ${response.status}). Check your Apple ID and app-specific password.`);
@@ -72,12 +210,9 @@ async function discoverCalendarHome(principalUrl, appleId, appPassword) {
   });
 
   if (response.status === 207 || response.status === 200) {
-    const body = response.data;
-    const hrefMatch = body.match(/<[^>]*:?calendar-home-set[^>]*>[\s\S]*?<[^>]*:?href[^>]*>([^<]+)<\/[^>]*:?href>/i);
-    if (hrefMatch) {
-      const href = hrefMatch[1].trim();
-      return href.startsWith('http') ? href : `${CALDAV_BASE}${href}`;
-    }
+    const homeUrl = parseCalendarHomeUrl(response.data);
+    if (homeUrl) return homeUrl;
+
     // Fallback: derive from principal URL (Apple structure is /DSID/principal -> /DSID/calendars/)
     const dsidMatch = principalUrl.match(/\/(\d+)\//);
     if (dsidMatch) {
@@ -119,38 +254,7 @@ async function listCalendars(calendarHomeUrl, appleId, appPassword) {
     throw new Error(`Failed to list iCloud calendars (HTTP ${response.status}).`);
   }
 
-  const body = response.data;
-  const calendars = [];
-
-  // Parse multistatus responses - each <response> element is a calendar or collection
-  const responseBlocks = body.match(/<[^>]*:?response[^>]*>[\s\S]*?<\/[^>]*:?response>/gi) || [];
-
-  for (const block of responseBlocks) {
-    // Must be a calendar (vevent support)
-    const isCalendar = block.includes('calendar') && !block.includes('calendar-home-set');
-    const hasVEvent = block.includes('VEVENT') || block.includes('vevent');
-    if (!isCalendar || !hasVEvent) continue;
-
-    const hrefMatch = block.match(/<[^>]*:?href[^>]*>([^<]+)<\/[^>]*:?href>/i);
-    const nameMatch = block.match(/<[^>]*:?displayname[^>]*>([^<]*)<\/[^>]*:?displayname>/i);
-    const colorMatch = block.match(/<[^>]*:?calendar-color[^>]*>([^<]*)<\/[^>]*:?calendar-color>/i);
-
-    if (!hrefMatch) continue;
-
-    const href = hrefMatch[1].trim();
-    const calUrl = href.startsWith('http') ? href : `${CALDAV_BASE}${href}`;
-    const name = nameMatch ? nameMatch[1].trim() : 'Calendar';
-    let color = colorMatch ? colorMatch[1].trim() : null;
-
-    // Apple returns colors like #RRGGBBAA, normalize to #RRGGBB
-    if (color && color.length === 9 && color.startsWith('#')) {
-      color = color.slice(0, 7);
-    }
-
-    calendars.push({ id: calUrl, name, color: color || '#3d7ab5', url: calUrl });
-  }
-
-  return calendars;
+  return parseCalendars(response.data);
 }
 
 // Full discovery flow: credentials -> list of calendars
@@ -159,6 +263,35 @@ async function discoverAndListCalendars(appleId, appPassword) {
   const homeUrl = await discoverCalendarHome(principalUrl, appleId, appPassword);
   const calendars = await listCalendars(homeUrl, appleId, appPassword);
   return { principalUrl, homeUrl, calendars };
+}
+
+// Convert a parsed ICS payload into HomeGlow event objects.
+function icsToEvents(icsContent) {
+  const comp = new ICAL.Component(ICAL.parse(icsContent));
+  const vevents = comp.getAllSubcomponents('vevent');
+  const events = [];
+
+  for (const vevent of vevents) {
+    const event = new ICAL.Event(vevent);
+    const dtstart = vevent.getFirstPropertyValue('dtstart');
+    const isAllDay = dtstart?.isDate ?? false;
+    const startDate = event.startDate.toJSDate();
+    const rawEnd = event.endDate.toJSDate();
+    const endDate = isAllDay ? subtractOneDay(rawEnd) : rawEnd;
+
+    events.push({
+      uid: event.uid || `apple-${Date.now()}-${Math.random()}`,
+      title: event.summary || 'Untitled Event',
+      start: startDate,
+      end: endDate,
+      description: event.description || null,
+      location: event.location || null,
+      all_day: isAllDay,
+      raw: {},
+    });
+  }
+
+  return events;
 }
 
 // Fetch events from a specific calendar URL using CalDAV REPORT
@@ -201,41 +334,11 @@ async function fetchCalendarEvents(calendarUrl, appleId, appPassword) {
     throw new Error(`Failed to fetch iCloud events (HTTP ${response.status}).`);
   }
 
-  const body = response.data;
   const events = [];
 
-  // Extract calendar-data blocks from multistatus
-  const calDataMatches = body.match(/<[^>]*:?calendar-data[^>]*>([\s\S]*?)<\/[^>]*:?calendar-data>/gi) || [];
-
-  for (const match of calDataMatches) {
-    const icsContent = extractIcsFromCalendarData(match);
-
-    if (!icsContent) continue;
-
+  for (const icsContent of extractIcsPayloads(response.data)) {
     try {
-      const jcalData = ICAL.parse(icsContent);
-      const comp = new ICAL.Component(jcalData);
-      const vevents = comp.getAllSubcomponents('vevent');
-
-      for (const vevent of vevents) {
-        const event = new ICAL.Event(vevent);
-        const dtstart = vevent.getFirstPropertyValue('dtstart');
-        const isAllDay = dtstart?.isDate ?? false;
-        const startDate = event.startDate.toJSDate();
-        const rawEnd = event.endDate.toJSDate();
-        const endDate = isAllDay ? subtractOneDay(rawEnd) : rawEnd;
-
-        events.push({
-          uid: event.uid || `apple-${Date.now()}-${Math.random()}`,
-          title: event.summary || 'Untitled Event',
-          start: startDate,
-          end: endDate,
-          description: event.description || null,
-          location: event.location || null,
-          all_day: isAllDay,
-          raw: {},
-        });
-      }
+      events.push(...icsToEvents(icsContent));
     } catch (err) {
       console.warn('Failed to parse Apple CalDAV event block:', err.message);
     }
@@ -250,51 +353,13 @@ function subtractOneDay(date) {
   return d;
 }
 
-// Decode the minimal set of XML entities that can appear in non-CDATA
-// calendar-data payloads. iCloud wraps its payload in CDATA, but other CalDAV
-// servers may return entity-encoded ICS instead.
-function decodeXmlEntities(text) {
-  return text
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(Number(dec)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
-    // Ampersand must be decoded last so we don't double-decode the entities above.
-    .replace(/&amp;/g, '&');
-}
-
-// Extract the raw ICS text from a single <calendar-data>...</calendar-data>
-// block. iCloud returns the ICS wrapped in a CDATA section; those markers must
-// be removed before handing the content to ICAL.parse, otherwise the first line
-// becomes "<![CDATA[BEGIN:VCALENDAR" and ical.js never initializes its design
-// set (throwing "Cannot read properties of undefined (reading 'propertyGroups')").
-function extractIcsFromCalendarData(block) {
-  let content = block
-    .replace(/<[^>]*:?calendar-data[^>]*>/i, '')
-    .replace(/<\/[^>]*:?calendar-data>/i, '')
-    .trim();
-
-  const cdataMatch = content.match(/^<!\[CDATA\[([\s\S]*?)\]\]>$/);
-  if (cdataMatch) {
-    // CDATA content is literal; no entity decoding required.
-    return cdataMatch[1].trim();
-  }
-
-  // Defensive: strip stray CDATA markers if the regex above didn't match
-  // (e.g. trailing whitespace variations), then decode XML entities for
-  // servers that return entity-encoded ICS instead of CDATA.
-  content = content
-    .replace(/^<!\[CDATA\[/i, '')
-    .replace(/\]\]>$/i, '')
-    .trim();
-
-  return decodeXmlEntities(content).trim();
-}
-
 module.exports = {
   discoverAndListCalendars,
   fetchCalendarEvents,
-  extractIcsFromCalendarData,
+  // Exported for unit testing (pure XML/ICS helpers, no network).
+  parsePrincipalUrl,
+  parseCalendarHomeUrl,
+  parseCalendars,
+  extractIcsPayloads,
+  icsToEvents,
 };

--- a/server/services/appleCalDAV.js
+++ b/server/services/appleCalDAV.js
@@ -208,10 +208,7 @@ async function fetchCalendarEvents(calendarUrl, appleId, appPassword) {
   const calDataMatches = body.match(/<[^>]*:?calendar-data[^>]*>([\s\S]*?)<\/[^>]*:?calendar-data>/gi) || [];
 
   for (const match of calDataMatches) {
-    const icsContent = match
-      .replace(/<[^>]*:?calendar-data[^>]*>/i, '')
-      .replace(/<\/[^>]*:?calendar-data>/i, '')
-      .trim();
+    const icsContent = extractIcsFromCalendarData(match);
 
     if (!icsContent) continue;
 
@@ -253,7 +250,51 @@ function subtractOneDay(date) {
   return d;
 }
 
+// Decode the minimal set of XML entities that can appear in non-CDATA
+// calendar-data payloads. iCloud wraps its payload in CDATA, but other CalDAV
+// servers may return entity-encoded ICS instead.
+function decodeXmlEntities(text) {
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(Number(dec)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    // Ampersand must be decoded last so we don't double-decode the entities above.
+    .replace(/&amp;/g, '&');
+}
+
+// Extract the raw ICS text from a single <calendar-data>...</calendar-data>
+// block. iCloud returns the ICS wrapped in a CDATA section; those markers must
+// be removed before handing the content to ICAL.parse, otherwise the first line
+// becomes "<![CDATA[BEGIN:VCALENDAR" and ical.js never initializes its design
+// set (throwing "Cannot read properties of undefined (reading 'propertyGroups')").
+function extractIcsFromCalendarData(block) {
+  let content = block
+    .replace(/<[^>]*:?calendar-data[^>]*>/i, '')
+    .replace(/<\/[^>]*:?calendar-data>/i, '')
+    .trim();
+
+  const cdataMatch = content.match(/^<!\[CDATA\[([\s\S]*?)\]\]>$/);
+  if (cdataMatch) {
+    // CDATA content is literal; no entity decoding required.
+    return cdataMatch[1].trim();
+  }
+
+  // Defensive: strip stray CDATA markers if the regex above didn't match
+  // (e.g. trailing whitespace variations), then decode XML entities for
+  // servers that return entity-encoded ICS instead of CDATA.
+  content = content
+    .replace(/^<!\[CDATA\[/i, '')
+    .replace(/\]\]>$/i, '')
+    .trim();
+
+  return decodeXmlEntities(content).trim();
+}
+
 module.exports = {
   discoverAndListCalendars,
   fetchCalendarEvents,
+  extractIcsFromCalendarData,
 };

--- a/server/services/appleCalDAV.js
+++ b/server/services/appleCalDAV.js
@@ -103,21 +103,26 @@ function parseCalendars(xmlBody) {
     const href = nodeText(response.href);
     if (!href) continue;
 
-    // Must be a calendar collection (resourcetype contains <calendar/>).
-    const resourcetype = findProp(response, 'resourcetype');
-    const isCalendar = !!resourcetype && typeof resourcetype === 'object' && 'calendar' in resourcetype;
-    if (!isCalendar) continue;
-
-    // If the server advertises supported components, require VEVENT support so
-    // we skip task/reminder-only collections.
+    // A collection holds events if it advertises VEVENT in its supported
+    // component set. This is the most reliable signal and works across regular,
+    // shared, and subscribed iCloud calendars (subscriptions use a
+    // <cs:subscribed/> resourcetype rather than <C:calendar/>, so we must not
+    // gate on resourcetype alone).
     const compSet = findProp(response, 'supported-calendar-component-set');
     const comps = compSet ? asArray(compSet.comp) : [];
-    if (comps.length > 0) {
-      const supportsVevent = comps.some(
-        (comp) => String(comp && comp['@_name'] ? comp['@_name'] : '').toUpperCase() === 'VEVENT'
-      );
-      if (!supportsVevent) continue;
-    }
+    const supportsVevent = comps.some(
+      (comp) => String(comp && comp['@_name'] ? comp['@_name'] : '').toUpperCase() === 'VEVENT'
+    );
+
+    // Fallback when no component set is advertised: accept calendar/subscribed
+    // resource types (covers servers that omit supported-calendar-component-set)
+    // while still excluding the calendar-home root and inbox/outbox collections.
+    const resourcetype = findProp(response, 'resourcetype');
+    const isCalendarResourceType = !!resourcetype && typeof resourcetype === 'object'
+      && ('calendar' in resourcetype || 'subscribed' in resourcetype);
+
+    const include = comps.length > 0 ? supportsVevent : isCalendarResourceType;
+    if (!include) continue;
 
     const name = nodeText(findProp(response, 'displayname')) || 'Calendar';
     let color = nodeText(findProp(response, 'calendar-color'));

--- a/server/tests/appleCalDAV.test.js
+++ b/server/tests/appleCalDAV.test.js
@@ -174,3 +174,40 @@ test('parseCalendars returns VEVENT calendars and skips non-calendar / VTODO-onl
     // #RRGGBBAA normalized to #RRGGBB
     assert.equal(calendars[0].color, '#FF2968');
 });
+
+test('parseCalendars includes shared/subscribed calendars that advertise VEVENT', () => {
+    // Subscribed iCloud calendars use <cs:subscribed/> instead of <C:calendar/>
+    // but still advertise VEVENT support. Regression: these were being dropped.
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav"
+             xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
+  <response>
+    <href>/123456/calendars/work/</href>
+    <propstat><prop>
+      <displayname>Work</displayname>
+      <resourcetype><collection/><caldav:calendar/></resourcetype>
+      <caldav:supported-calendar-component-set><caldav:comp name="VEVENT"/></caldav:supported-calendar-component-set>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+  <response>
+    <href>/123456/calendars/holidays/</href>
+    <propstat><prop>
+      <displayname>US Holidays</displayname>
+      <resourcetype><collection/><cs:subscribed/></resourcetype>
+      <caldav:supported-calendar-component-set><caldav:comp name="VEVENT"/></caldav:supported-calendar-component-set>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+  <response>
+    <href>/123456/calendars/legacy/</href>
+    <propstat><prop>
+      <displayname>Legacy</displayname>
+      <resourcetype><collection/><caldav:calendar/></resourcetype>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+</multistatus>`;
+
+    const calendars = parseCalendars(body);
+    const names = calendars.map((c) => c.name).sort();
+    // Work + subscribed Holidays (VEVENT) + Legacy (no comp set, calendar resourcetype)
+    assert.deepEqual(names, ['Legacy', 'US Holidays', 'Work']);
+});

--- a/server/tests/appleCalDAV.test.js
+++ b/server/tests/appleCalDAV.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const ICAL = require('ical.js');
+const { extractIcsFromCalendarData } = require('../services/appleCalDAV');
+
+// Anonymized fixtures: no real names, emails, or principal/DSID values.
+const ANON_VEVENT = [
+    'BEGIN:VEVENT',
+    'ATTENDEE;CN=Jane Doe;CUTYPE=INDIVIDUAL;EMAIL=jane@example.com',
+    ' ;PARTSTAT=ACCEPTED;ROLE=CHAIR:/principal/',
+    'CREATED:20251215T153939Z',
+    'DTEND;TZID=America/Chicago:20260309T104500',
+    'DTSTART;TZID=America/Chicago:20260309T094500',
+    'SUMMARY:Sample Event',
+    'UID:00000000-0000-0000-0000-000000000000',
+    'DTSTAMP:20260108T022826Z',
+    'TRANSP:OPAQUE',
+    'END:VEVENT',
+].join('\r\n');
+
+const ANON_VCALENDAR = [
+    'BEGIN:VCALENDAR',
+    'CALSCALE:GREGORIAN',
+    'PRODID:-//Example Inc.//Example//EN',
+    'VERSION:2.0',
+    ANON_VEVENT,
+    'END:VCALENDAR',
+].join('\r\n');
+
+// Mirrors the shape iCloud returns: calendar-data wrapped in a CDATA section.
+function buildCdataResponseBlock(icsBody) {
+    return [
+        '<calendar-data xmlns="urn:ietf:params:xml:ns:caldav">',
+        `<![CDATA[${icsBody}`,
+        ']]>',
+        '</calendar-data>',
+    ].join('\n');
+}
+
+// Some CalDAV servers return entity-encoded ICS instead of CDATA.
+function buildEntityEncodedResponseBlock(icsBody) {
+    const encoded = icsBody
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    return `<calendar-data xmlns="urn:ietf:params:xml:ns:caldav">${encoded}</calendar-data>`;
+}
+
+test('extractIcsFromCalendarData strips the CDATA wrapper', () => {
+    const block = buildCdataResponseBlock(ANON_VCALENDAR);
+    const ics = extractIcsFromCalendarData(block);
+
+    assert.ok(ics.startsWith('BEGIN:VCALENDAR'), 'first line must be BEGIN:VCALENDAR');
+    assert.ok(!ics.includes('<![CDATA['), 'CDATA opening marker must be removed');
+    assert.ok(!ics.includes(']]>'), 'CDATA closing marker must be removed');
+});
+
+test('CDATA-wrapped calendar-data parses cleanly with ical.js', () => {
+    const block = buildCdataResponseBlock(ANON_VCALENDAR);
+    const ics = extractIcsFromCalendarData(block);
+
+    // Regression: previously threw "Cannot read properties of undefined
+    // (reading 'propertyGroups')" because the CDATA prefix prevented ical.js
+    // from initializing its design set on the first line.
+    const comp = new ICAL.Component(ICAL.parse(ics));
+    const vevents = comp.getAllSubcomponents('vevent');
+
+    assert.equal(vevents.length, 1);
+    const event = new ICAL.Event(vevents[0]);
+    assert.equal(event.summary, 'Sample Event');
+    assert.equal(event.uid, '00000000-0000-0000-0000-000000000000');
+});
+
+test('extractIcsFromCalendarData decodes entity-encoded (non-CDATA) calendar-data', () => {
+    const block = buildEntityEncodedResponseBlock(ANON_VCALENDAR);
+    const ics = extractIcsFromCalendarData(block);
+
+    assert.ok(ics.startsWith('BEGIN:VCALENDAR'));
+    const comp = new ICAL.Component(ICAL.parse(ics));
+    assert.equal(comp.getAllSubcomponents('vevent').length, 1);
+});

--- a/server/tests/appleCalDAV.test.js
+++ b/server/tests/appleCalDAV.test.js
@@ -1,10 +1,19 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const ICAL = require('ical.js');
-const { extractIcsFromCalendarData } = require('../services/appleCalDAV');
+const {
+    parsePrincipalUrl,
+    parseCalendarHomeUrl,
+    parseCalendars,
+    extractIcsPayloads,
+    icsToEvents,
+} = require('../services/appleCalDAV');
 
 // Anonymized fixtures: no real names, emails, or principal/DSID values.
-const ANON_VEVENT = [
+const ANON_VCALENDAR = [
+    'BEGIN:VCALENDAR',
+    'CALSCALE:GREGORIAN',
+    'PRODID:-//Example Inc.//Example//EN',
+    'VERSION:2.0',
     'BEGIN:VEVENT',
     'ATTENDEE;CN=Jane Doe;CUTYPE=INDIVIDUAL;EMAIL=jane@example.com',
     ' ;PARTSTAT=ACCEPTED;ROLE=CHAIR:/principal/',
@@ -16,66 +25,152 @@ const ANON_VEVENT = [
     'DTSTAMP:20260108T022826Z',
     'TRANSP:OPAQUE',
     'END:VEVENT',
-].join('\r\n');
-
-const ANON_VCALENDAR = [
-    'BEGIN:VCALENDAR',
-    'CALSCALE:GREGORIAN',
-    'PRODID:-//Example Inc.//Example//EN',
-    'VERSION:2.0',
-    ANON_VEVENT,
     'END:VCALENDAR',
 ].join('\r\n');
 
-// Mirrors the shape iCloud returns: calendar-data wrapped in a CDATA section.
-function buildCdataResponseBlock(icsBody) {
-    return [
-        '<calendar-data xmlns="urn:ietf:params:xml:ns:caldav">',
-        `<![CDATA[${icsBody}`,
-        ']]>',
-        '</calendar-data>',
-    ].join('\n');
+// Wrap an ICS body in a calendar REPORT multistatus, the way iCloud does: the
+// calendar-data is inside a CDATA section.
+function buildReportWithCdata(icsBody) {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav">
+  <response>
+    <href>/123456/calendars/home/event.ics</href>
+    <propstat>
+      <prop>
+        <getetag>"abc123"</getetag>
+        <caldav:calendar-data><![CDATA[${icsBody}]]></caldav:calendar-data>
+      </prop>
+      <status>HTTP/1.1 200 OK</status>
+    </propstat>
+  </response>
+</multistatus>`;
 }
 
 // Some CalDAV servers return entity-encoded ICS instead of CDATA.
-function buildEntityEncodedResponseBlock(icsBody) {
+function buildReportWithEntities(icsBody) {
     const encoded = icsBody
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;');
-    return `<calendar-data xmlns="urn:ietf:params:xml:ns:caldav">${encoded}</calendar-data>`;
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav">
+  <response>
+    <href>/123456/calendars/home/event.ics</href>
+    <propstat>
+      <prop>
+        <caldav:calendar-data>${encoded}</caldav:calendar-data>
+      </prop>
+      <status>HTTP/1.1 200 OK</status>
+    </propstat>
+  </response>
+</multistatus>`;
 }
 
-test('extractIcsFromCalendarData strips the CDATA wrapper', () => {
-    const block = buildCdataResponseBlock(ANON_VCALENDAR);
-    const ics = extractIcsFromCalendarData(block);
+test('extractIcsPayloads unwraps CDATA calendar-data (regression: propertyGroups)', () => {
+    const payloads = extractIcsPayloads(buildReportWithCdata(ANON_VCALENDAR));
 
-    assert.ok(ics.startsWith('BEGIN:VCALENDAR'), 'first line must be BEGIN:VCALENDAR');
-    assert.ok(!ics.includes('<![CDATA['), 'CDATA opening marker must be removed');
-    assert.ok(!ics.includes(']]>'), 'CDATA closing marker must be removed');
+    assert.equal(payloads.length, 1);
+    assert.ok(payloads[0].startsWith('BEGIN:VCALENDAR'), 'first line must be BEGIN:VCALENDAR');
+    assert.ok(!payloads[0].includes('<![CDATA['), 'CDATA marker must be gone');
+    assert.ok(!payloads[0].includes(']]>'), 'CDATA marker must be gone');
+
+    // Previously threw "Cannot read properties of undefined (reading 'propertyGroups')".
+    const events = icsToEvents(payloads[0]);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].title, 'Sample Event');
+    assert.equal(events[0].uid, '00000000-0000-0000-0000-000000000000');
+    assert.equal(events[0].all_day, false);
 });
 
-test('CDATA-wrapped calendar-data parses cleanly with ical.js', () => {
-    const block = buildCdataResponseBlock(ANON_VCALENDAR);
-    const ics = extractIcsFromCalendarData(block);
+test('extractIcsPayloads decodes entity-encoded (non-CDATA) calendar-data', () => {
+    const payloads = extractIcsPayloads(buildReportWithEntities(ANON_VCALENDAR));
 
-    // Regression: previously threw "Cannot read properties of undefined
-    // (reading 'propertyGroups')" because the CDATA prefix prevented ical.js
-    // from initializing its design set on the first line.
-    const comp = new ICAL.Component(ICAL.parse(ics));
-    const vevents = comp.getAllSubcomponents('vevent');
-
-    assert.equal(vevents.length, 1);
-    const event = new ICAL.Event(vevents[0]);
-    assert.equal(event.summary, 'Sample Event');
-    assert.equal(event.uid, '00000000-0000-0000-0000-000000000000');
+    assert.equal(payloads.length, 1);
+    assert.ok(payloads[0].startsWith('BEGIN:VCALENDAR'));
+    assert.equal(icsToEvents(payloads[0]).length, 1);
 });
 
-test('extractIcsFromCalendarData decodes entity-encoded (non-CDATA) calendar-data', () => {
-    const block = buildEntityEncodedResponseBlock(ANON_VCALENDAR);
-    const ics = extractIcsFromCalendarData(block);
+test('extractIcsPayloads handles multiple responses and skips empty ones', () => {
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav">
+  <response>
+    <href>/123456/calendars/home/a.ics</href>
+    <propstat><prop><caldav:calendar-data><![CDATA[${ANON_VCALENDAR}]]></caldav:calendar-data></prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+  <response>
+    <href>/123456/calendars/home/missing.ics</href>
+    <propstat><prop/><status>HTTP/1.1 404 Not Found</status></propstat>
+  </response>
+  <response>
+    <href>/123456/calendars/home/b.ics</href>
+    <propstat><prop><caldav:calendar-data><![CDATA[${ANON_VCALENDAR}]]></caldav:calendar-data></prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+</multistatus>`;
 
-    assert.ok(ics.startsWith('BEGIN:VCALENDAR'));
-    const comp = new ICAL.Component(ICAL.parse(ics));
-    assert.equal(comp.getAllSubcomponents('vevent').length, 1);
+    assert.equal(extractIcsPayloads(body).length, 2);
+});
+
+test('parsePrincipalUrl extracts and absolutizes the current-user-principal href', () => {
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:">
+  <response>
+    <href>/</href>
+    <propstat>
+      <prop><current-user-principal><href>/123456/principal/</href></current-user-principal></prop>
+      <status>HTTP/1.1 200 OK</status>
+    </propstat>
+  </response>
+</multistatus>`;
+
+    assert.equal(parsePrincipalUrl(body), 'https://caldav.icloud.com/123456/principal/');
+});
+
+test('parseCalendarHomeUrl extracts the calendar-home-set href', () => {
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav">
+  <response>
+    <href>/123456/principal/</href>
+    <propstat>
+      <prop><caldav:calendar-home-set><href>/123456/calendars/</href></caldav:calendar-home-set></prop>
+      <status>HTTP/1.1 200 OK</status>
+    </propstat>
+  </response>
+</multistatus>`;
+
+    assert.equal(parseCalendarHomeUrl(body), 'https://caldav.icloud.com/123456/calendars/');
+});
+
+test('parseCalendars returns VEVENT calendars and skips non-calendar / VTODO-only collections', () => {
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav"
+             xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
+  <response>
+    <href>/123456/calendars/</href>
+    <propstat><prop><resourcetype><collection/></resourcetype></prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+  <response>
+    <href>/123456/calendars/home/</href>
+    <propstat><prop>
+      <displayname>Family</displayname>
+      <resourcetype><collection/><caldav:calendar/></resourcetype>
+      <ical:calendar-color>#FF2968FF</ical:calendar-color>
+      <caldav:supported-calendar-component-set><caldav:comp name="VEVENT"/></caldav:supported-calendar-component-set>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+  <response>
+    <href>/123456/calendars/tasks/</href>
+    <propstat><prop>
+      <displayname>Reminders</displayname>
+      <resourcetype><collection/><caldav:calendar/></resourcetype>
+      <caldav:supported-calendar-component-set><caldav:comp name="VTODO"/></caldav:supported-calendar-component-set>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+</multistatus>`;
+
+    const calendars = parseCalendars(body);
+    assert.equal(calendars.length, 1);
+    assert.equal(calendars[0].name, 'Family');
+    assert.equal(calendars[0].url, 'https://caldav.icloud.com/123456/calendars/home/');
+    // #RRGGBBAA normalized to #RRGGBB
+    assert.equal(calendars[0].color, '#FF2968');
 });


### PR DESCRIPTION
## Summary

Apple/iCloud calendar sources never synced any events. Every event block failed with:

```
Failed to parse Apple CalDAV event block: Cannot read properties of undefined (reading 'propertyGroups')
```

### Root cause
iCloud returns the `<calendar-data>` payload wrapped in a CDATA section. The extraction in `fetchCalendarEvents()` stripped the `<calendar-data>` tags but left the `<![CDATA[ ... ]]>` markers, so the string handed to `ICAL.parse()` started with `<![CDATA[BEGIN:VCALENDAR` instead of `BEGIN:VCALENDAR`. Because the first line was not a valid `BEGIN:`, ical.js never initialized its design set and the first property line dereferenced `state.designSet.propertyGroups` on `undefined` (ical.js `parse.js`).

### Changes
- Strip the CDATA wrapper from `<calendar-data>` before parsing.
- Decode XML entities for CalDAV servers that return entity-encoded (non-CDATA) calendar-data.
- Extract the logic into an exported `extractIcsFromCalendarData()` helper.
- Add `server/.dockerignore` and `client/.dockerignore` so host-built `node_modules` are never copied into the Linux images — fixes `better-sqlite3` `invalid ELF header` when building from a macOS/Windows host and prevents esbuild/rollup platform mismatches on the client.

### Testing
- New `server/tests/appleCalDAV.test.js` (anonymized fixtures) covers CDATA stripping, end-to-end ical.js parse of a CDATA-wrapped payload (the exact regression), and the entity-encoded fallback.
- `npm test` in `server/` passes: 29 tests, 0 failures (3 new).