### PR TITLE
chore: gitignore local dev artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ coverage/
 package-lock.json
 
 .vscode/
+
+# Local dev runtime data created by docker-compose-dev.yml (SQLite DB, uploads,
+# auto-generated encryption key) — must never be committed.
+homeglowdev/
+
+# IDE / tooling
+.idea/
+.tool-versions


### PR DESCRIPTION
Adds local dev artifacts to .gitignore so they do not show up as untracked or get committed accidentally:

- `homeglowdev/` — created by `docker-compose-dev.yml`; contains the local SQLite DB and the auto-generated encryption key (must never be committed).
- `.idea/` — JetBrains IDE settings.
- `.tool-versions` — asdf/local tool version pins.

No functional changes.
