### PR TITLE
fix(photos): Immich v3 album support via search/metadata

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3989,11 +3989,22 @@ fastify.get('/api/photo-items', async (request, reply) => {
           let assets = [];
 
           if (source.album_id) {
-            const albumResponse = await axios.get(`${apiBase}/albums/${source.album_id}`, {
-              headers: immichHeaders,
-              timeout: 15000
-            });
-            assets = albumResponse.data?.assets || [];
+            // Immich v3 removed the `assets` array from GET /api/albums/{id}
+            // (https://immich.app/blog/v3-migration). Fetch album assets via the
+            // paginated metadata search instead — works on both Immich v2 and v3.
+            let page = 1;
+            while (page && assets.length < 1000) {
+              const searchResponse = await axios.post(`${apiBase}/search/metadata`,
+                { albumIds: [source.album_id], page, size: 1000 },
+                {
+                  headers: immichHeaders,
+                  timeout: 15000
+                }
+              );
+              const bucket = searchResponse.data?.assets || {};
+              assets.push(...(bucket.items || []));
+              page = bucket.nextPage ? Number(bucket.nextPage) : null;
+            }
             for (let i = assets.length - 1; i > 0; i--) {
               const j = Math.floor(Math.random() * (i + 1));
               [assets[i], assets[j]] = [assets[j], assets[i]];


### PR DESCRIPTION
## Summary

Fixes the **Immich photo widget showing no photos when an album ID is configured**, after upgrading the Immich server to **v3**.

## Root cause

Immich v3 [removed the `assets` array from `GET /api/albums/{id}`](https://immich.app/blog/v3-migration):

> **Albums** — "The `assets` property has been removed (use `POST /api/search/metadata` instead)."

The `/api/photo-items` handler relied on that field:

```js
const albumResponse = await axios.get(`${apiBase}/albums/${source.album_id}`, ...);
assets = albumResponse.data?.assets || [];   // undefined on v3 → []
```

On v3 the request still returns `200`, but `assets` is `undefined`, so the widget silently renders **zero photos**. Only album mode is affected — the no-album path uses `POST /api/search/random`, which v3 did not change.

## Fix

Fetch album assets via the paginated `POST /api/search/metadata` endpoint, filtered by `albumIds`. This works on **both Immich v2 and v3**, so it's a safe drop-in, and it also handles albums larger than the previous single-response limit.

## Changes
- `server/index.js` — album-mode Immich fetch now pages through `POST /api/search/metadata` instead of reading `assets` off `GET /api/albums/{id}`.

## Notes
- The connection **test** uses `POST /api/search/random`, so it keeps passing on v3 even while albums are broken — worth knowing when triaging.
- Downstream asset mapping (`id`/`type` → `/api/photo-proxy/...`) is unchanged; `search/metadata` items carry the same shape.
