### PR TITLE
Stop the composition quickly

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -18,6 +18,8 @@ services:
       dockerfile: Dockerfile
       args:
         - PORT=${DEV_BACKEND_PORT:-5001}
+    # Ensures SIGTERM reaches Node
+    init: true
     ports:
       - "${DEV_BACKEND_PORT:-5001}:${DEV_BACKEND_PORT:-5001}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
   homeglow-backend:
     container_name: homeglow-backend
     image: ghcr.io/jherforth/homeglow-backend:latest
+    # Ensures SIGTERM reaches Node
+    init: true
     volumes:
       - ./homeglow/data:/app/data
       - ./homeglow/uploads:/app/uploads

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -46,5 +46,5 @@ RUN mkdir -p /app/uploads/users /app/widgets && chmod -R 777 /app/uploads /app/w
 
 # Expose the port
 EXPOSE ${PORT}
-
-CMD ["node", "index.js"]
+ENTRYPOINT ["node"]
+CMD ["index.js"]


### PR DESCRIPTION
Pressing ^c should stop the docker composition. Before this change the backend would ignore the initial SIGINT that docker compose sent, wait 10 seconds, then docker would send a SIGKILL. Instead, node should handle the SIGINT immediately and stop.