### PR TITLE
CalendarWidget was calling /api/calendar-events with no date range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Ignore all .env files
 .env
 
-# Optionally, ignore .env files in subdirectories too
-**/.env
-
 # You might also want to ignore node_modules and build outputs
 node_modules/
 dist/
@@ -29,8 +26,9 @@ server/data/.encryption-key
 
 # Local dev runtime data created by docker-compose-dev.yml (SQLite DB, uploads,
 # auto-generated encryption key) — must never be committed.
-homeglowdev/
+/homeglowdev/
 
 # IDE / tooling
 .idea/
 .tool-versions
+/homeglow

--- a/client/src/components/CalendarWidget.jsx
+++ b/client/src/components/CalendarWidget.jsx
@@ -179,7 +179,6 @@ const CalendarWidget = ({
   const isMobile = useIsMobile();
   const defaultViewMode = isMobile ? 'week' : 'month';
   const [events, setEvents] = useState([]);
-  const [upcomingEvents, setUpcomingEvents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [selectedDate, setSelectedDate] = useState(null);
@@ -243,7 +242,6 @@ const CalendarWidget = ({
   // Initial data fetch
   useEffect(() => {
     fetchCalendarSources();
-    fetchCalendarEvents();
     fetchSyncStatus();
     fetchDedupSetting();
   }, []);
@@ -257,6 +255,12 @@ const CalendarWidget = ({
     fetchCalendarSources();
     fetchCalendarEvents();
   }, [refreshNonce]);
+
+  // Refetch only when the visible month (or view mode) changes to keep the fetch small.
+  const eventsRangeKey = `${viewMode}:${moment(currentDate).format('YYYY-MM')}`;
+  useEffect(() => {
+    fetchCalendarEvents();
+  }, [eventsRangeKey]);
 
   useEffect(() => {
     const loadCalendarWidgetSettings = async () => {
@@ -503,7 +507,14 @@ const CalendarWidget = ({
       setLoading(true);
       setError(null);
 
-      const response = await axios.get(`${API_BASE_URL}/api/calendar-events`);
+      // Limit the query to the visible range (+ padding). Fetching the entire
+      // multi-year cache can be big and blocks every other API request.
+      const start = moment(currentDate).startOf(viewMode).subtract(1, 'month').toISOString();
+      const end = moment(currentDate).endOf(viewMode).add(2, 'months').toISOString();
+
+      const response = await axios.get(`${API_BASE_URL}/api/calendar-events`, {
+        params: { start, end },
+      });
 
       if (Array.isArray(response.data)) {
         const formattedEvents = response.data.map(event => ({
@@ -523,31 +534,17 @@ const CalendarWidget = ({
         }));
 
         setEvents(formattedEvents);
-
-        const now = new Date();
-        const nextWeek = new Date();
-        nextWeek.setDate(now.getDate() + 7);
-
-        const upcoming = formattedEvents
-          .filter(event => event.start >= now && event.start <= nextWeek)
-          .sort((a, b) => a.start - b.start)
-          .slice(0, 5);
-
-        setUpcomingEvents(upcoming);
       } else {
         setEvents([]);
-        setUpcomingEvents([]);
       }
     } catch (error) {
       console.error('Error fetching calendar events:', error);
       setError('Failed to load calendar events. Please configure calendars in settings.');
       setEvents([]);
-      setUpcomingEvents([]);
     } finally {
       setLoading(false);
     }
   };
-
   const loadGoogleCalendars = async () => {
     setGoogleCalendarsLoading(true);
     setGoogleCalendarsError('');

--- a/server/index.js
+++ b/server/index.js
@@ -1746,6 +1746,11 @@ async function ConnectOrCreateDb() {
 
     const newDb = new Database(dbPath, { verbose: console.log });
     newDb.pragma('foreign_keys = ON');
+    // WAL lets readers proceed while a writer is active (better-sqlite3 is still
+    // single-threaded, but this avoids POSIX lock stalls across connections).
+    if (dbPath !== ':memory:') {
+      newDb.pragma('journal_mode = WAL');
+    }
     return newDb;
   } catch (error) {
     console.error('Failed to connect or create database:', error);


### PR DESCRIPTION
This caused the server  to build, deduplicate, and serialize the entire multi-year cache on the Node main thread and stalled every other API call. Performance was unbearable:

https://github.com/user-attachments/assets/2c5c232c-bb71-4e98-8cd6-20743190b5e1

Now it's faster:


https://github.com/user-attachments/assets/cb4525a6-8aea-44a7-94a2-70fbb45dc564


