### PR TITLE
fix: upgrade @fastify/static to 10.1.3 with setHeaders API migration (CVE-2026-15074)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -474,9 +474,9 @@ fastify.register(require('@fastify/static'), {
   prefix: '/Uploads/',
   decorateReply: false,
   maxAge: 86400000, // 1 day cache
-  setHeaders: (res, path) => {
+  setHeaders: (reply, path) => {
     // Minimize headers to avoid "Request Header Fields Too Large" error
-    res.setHeader('Cache-Control', 'public, max-age=86400');
+    reply.header('Cache-Control', 'public, max-age=86400');
   }
 });
 
@@ -486,9 +486,9 @@ fastify.register(require('@fastify/static'), {
   prefix: '/Uploads/users/',
   decorateReply: false,
   maxAge: 86400000, // 1 day cache
-  setHeaders: (res, path) => {
+  setHeaders: (reply, path) => {
     // Minimize headers to avoid "Request Header Fields Too Large" error
-    res.setHeader('Cache-Control', 'public, max-age=86400');
+    reply.header('Cache-Control', 'public, max-age=86400');
   }
 });
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fastify/cors": "^11.1.0",
         "@fastify/multipart": "^10.0.0",
-        "@fastify/static": "^9.1.3",
+        "@fastify/static": "^10.1.3",
         "axios": "^1.15.2",
         "better-sqlite3": "^12.9.0",
         "cron-parser": "^5.5.0",
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
-      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.3.tgz",
+      "integrity": "sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==",
       "funding": [
         {
           "type": "github",
@@ -268,12 +268,29 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/error": "^4.0.0",
         "@fastify/send": "^4.0.0",
-        "content-disposition": "^1.0.1",
-        "fastify-plugin": "^5.0.0",
+        "content-disposition": "^2.0.1",
+        "fastify-plugin": "^6.0.0",
         "fastq": "^1.17.1",
         "glob": "^13.0.0"
       }
+    },
+    "node_modules/@fastify/static/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
@@ -695,9 +712,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+      "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@fastify/cors": "^11.1.0",
     "@fastify/multipart": "^10.0.0",
-    "@fastify/static": "^9.1.3",
+    "@fastify/static": "^10.1.3",
     "axios": "^1.15.2",
     "better-sqlite3": "^12.9.0",
     "cron-parser": "^5.5.0",

--- a/server/tests/defaultAvatars.test.js
+++ b/server/tests/defaultAvatars.test.js
@@ -120,6 +120,7 @@ test('seeded avatars are served from the uploads static root', async () => {
     const response = await fetch(`${baseUrl}/Uploads/users/defaults/cat.svg`);
     assert.equal(response.status, 200);
     assert.match(response.headers.get('content-type') || '', /image\/svg\+xml/);
+    assert.equal(response.headers.get('cache-control'), 'public, max-age=86400');
     assert.match(await response.text(), /<svg/);
 });
 


### PR DESCRIPTION
## Summary

Addresses the review feedback from [PR #135](https://github.com/jherforth/HomeGlow/pull/135#issuecomment-5267157101): the upgrade was right but the `setHeaders` callbacks needed reworking for the v10 API change.

- **Bump `@fastify/static`** from 9.1.3 → 10.1.3 (current latest patch, fixes CVE-2026-15074: route guard bypass via path traversal)
- **Migrate both `setHeaders` callbacks** in `server/index.js`: v10 passes a Fastify `Reply` instead of a Node `http.ServerResponse`, so `res.setHeader(name, val)` → `reply.header(name, val)` in both the `/Uploads/` and `/Uploads/users/` registrations
- **Add regression test**: extends the existing static-route test in `defaultAvatars.test.js` to assert `Cache-Control: public, max-age=86400` is present — catches any future `setHeaders` breakage

## Test plan

- [x] All 114 server tests pass (`npm test` in `server/`)
- [x] `GET /Uploads/users/defaults/cat.svg` returns `Cache-Control: public, max-age=86400`
- [x] New `Cache-Control` assertion guards against silent header regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)