### PR TITLE
Adds Photos Picker flow to Google Photos source

### DIFF
--- a/client/src/components/PhotoWidget.jsx
+++ b/client/src/components/PhotoWidget.jsx
@@ -26,6 +26,18 @@ const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
   const [testingConnection, setTestingConnection] = useState(false);
   const [testResult, setTestResult] = useState(null);
   const [savingSource, setSavingSource] = useState(false);
+  const [googleStatus, setGoogleStatus] = useState(null);
+  const [googleStatusLoading, setGoogleStatusLoading] = useState(false);
+  const [pickerWaiting, setPickerWaiting] = useState(false);
+  const [pickerUri, setPickerUri] = useState(null);
+  const [popupBlocked, setPopupBlocked] = useState(false);
+  const [pickerError, setPickerError] = useState(null);
+  const [pickerResult, setPickerResult] = useState(null);
+  const [pickedItems, setPickedItems] = useState([]);
+  const [pickedLoading, setPickedLoading] = useState(false);
+  const pollIntervalRef = useRef(null);
+  const pollTimeoutRef = useRef(null);
+  const pickerActiveRef = useRef(false);
   const [isPlaying, setIsPlaying] = useState(true);
   const [slideshowInterval, setSlideshowInterval] = useState(5000);
   const [photosPerView, setPhotosPerView] = useState(1);
@@ -211,6 +223,164 @@ const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
       setSavingSource(false);
     }
   };
+
+  // "5s" / "1799.969983s" → seconds as a number. Google returns picker
+  // pollingConfig values as duration strings, not numbers.
+  const parseDurationSeconds = (v) => {
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof v !== 'string') return null;
+    const m = v.match(/^([\d.]+)s?$/);
+    return m ? parseFloat(m[1]) : null;
+  };
+
+  const stopPicker = () => {
+    pickerActiveRef.current = false;
+    if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
+    if (pollTimeoutRef.current) { clearTimeout(pollTimeoutRef.current); pollTimeoutRef.current = null; }
+    setPickerWaiting(false);
+    setPickerUri(null);
+    setPopupBlocked(false);
+  };
+
+  const fetchGoogleStatus = async () => {
+    setGoogleStatusLoading(true);
+    try {
+      const response = await axios.get(`${API_BASE_URL}/api/connections/google/status`);
+      setGoogleStatus(response.data);
+    } catch (error) {
+      console.error('Error fetching Google connection status:', error);
+      setGoogleStatus(null);
+    } finally {
+      setGoogleStatusLoading(false);
+    }
+  };
+
+  const fetchPickedMedia = async (sourceId) => {
+    setPickedLoading(true);
+    try {
+      const response = await axios.get(`${API_BASE_URL}/api/photo-sources/${sourceId}/picked`);
+      setPickedItems(Array.isArray(response.data) ? response.data : []);
+    } catch (error) {
+      console.error('Error listing picked media:', error);
+      setPickedItems([]);
+    } finally {
+      setPickedLoading(false);
+    }
+  };
+
+  const handleDeletePicked = async (mediaRowId) => {
+    if (!editingSource) return;
+    try {
+      await axios.delete(`${API_BASE_URL}/api/photo-sources/${editingSource.id}/picked/${mediaRowId}`);
+      await fetchPickedMedia(editingSource.id);
+      await fetchPhotos();
+    } catch (error) {
+      console.error('Error deleting picked media:', error);
+    }
+  };
+
+  const ingestPickedSession = async (sourceId) => {
+    try {
+      const response = await axios.post(`${API_BASE_URL}/api/photo-sources/${sourceId}/picker-session/ingest`);
+      setPickerResult(response.data);
+      await fetchPickedMedia(sourceId);
+      await fetchPhotos();
+    } catch (error) {
+      console.error('Error ingesting picked media:', error);
+      setPickerError(error.response?.data?.error || t('photos:source.googlePicker.ingestFailed'));
+    }
+  };
+
+  const handleStartPicker = async () => {
+    if (!editingSource) return;
+    setPickerError(null);
+    setPickerResult(null);
+    setPickerWaiting(true);
+    let session;
+    try {
+      const response = await axios.post(`${API_BASE_URL}/api/photo-sources/${editingSource.id}/picker-session`);
+      session = response.data;
+    } catch (error) {
+      console.error('Error creating picker session:', error);
+      setPickerWaiting(false);
+      setPickerError(error.response?.data?.error || t('photos:source.googlePicker.startFailed'));
+      return;
+    }
+
+    const uri = session.pickerUri;
+    setPickerUri(uri);
+
+    const opened = uri ? window.open(uri, '_blank') : null;
+    if (opened) {
+      // Sever the opener reference so the Google-hosted page can't script back.
+      try { opened.opener = null; } catch (_) { /* cross-origin */ }
+    } else {
+      setPopupBlocked(true);
+    }
+
+    const pollSecs = parseDurationSeconds(session.pollingConfig?.pollInterval) || 5;
+    const timeoutSecs = parseDurationSeconds(session.pollingConfig?.timeoutIn) || 1800;
+    const sourceId = editingSource.id;
+
+    pickerActiveRef.current = true;
+
+    pollIntervalRef.current = setInterval(async () => {
+      if (!pickerActiveRef.current) return;
+      try {
+        const poll = await axios.get(`${API_BASE_URL}/api/photo-sources/${sourceId}/picker-session`);
+        if (poll.data?.mediaItemsSet && pickerActiveRef.current) {
+          stopPicker();
+          await ingestPickedSession(sourceId);
+        }
+      } catch (error) {
+        console.error('Error polling picker session:', error);
+      }
+    }, Math.max(1, pollSecs) * 1000);
+
+    pollTimeoutRef.current = setTimeout(() => {
+      if (pickerActiveRef.current) {
+        stopPicker();
+        setPickerError(t('photos:source.googlePicker.timedOut'));
+      }
+    }, Math.max(1, timeoutSecs) * 1000);
+  };
+
+  const handleCancelPicker = async () => {
+    const sourceId = editingSource?.id;
+    stopPicker();
+    if (sourceId) {
+      try {
+        await axios.delete(`${API_BASE_URL}/api/photo-sources/${sourceId}/picker-session`);
+      } catch (error) {
+        console.error('Error cancelling picker session:', error);
+      }
+    }
+  };
+
+  // Load Google status + picked media when the dialog opens on a GooglePhotos source.
+  useEffect(() => {
+    if (showSourceDialog && sourceForm.type === 'GooglePhotos') {
+      fetchGoogleStatus();
+      if (editingSource) {
+        fetchPickedMedia(editingSource.id);
+      } else {
+        setPickedItems([]);
+      }
+    }
+  }, [showSourceDialog, sourceForm.type, editingSource?.id]);
+
+  // Any time the dialog closes, tear down picker state so no timer survives.
+  useEffect(() => {
+    if (!showSourceDialog) {
+      stopPicker();
+      setPickerError(null);
+      setPickerResult(null);
+    }
+  }, [showSourceDialog]);
+
+  useEffect(() => {
+    return () => stopPicker();
+  }, []);
 
   const handleSettingsClick = (event) => {
     setSettingsAnchor(event.currentTarget);
@@ -589,6 +759,7 @@ const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
             >
               <MenuItem value="Immich">{t('photos:source.immich')}</MenuItem>
               <MenuItem value="HomeGlowPhotos">{t('photos:source.homeglow')}</MenuItem>
+              <MenuItem value="GooglePhotos">{t('photos:source.google')}</MenuItem>
             </Select>
           </FormControl>
 
@@ -621,6 +792,129 @@ const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
                 helperText={t('photos:source.albumIdHelp')}
               />
             </>
+          )}
+
+          {sourceForm.type === 'GooglePhotos' && (
+            <Box sx={{ mt: 2 }}>
+              {!editingSource ? (
+                <Alert severity="info">
+                  {t('photos:source.saveFirst')}
+                </Alert>
+              ) : googleStatusLoading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+                  <CircularProgress size={24} />
+                </Box>
+              ) : !googleStatus?.account ? (
+                <Alert severity="warning">
+                  {t('photos:source.googlePicker.noAccount')}
+                </Alert>
+              ) : !(googleStatus.account.scopes || '').includes('photoslibrary.readonly.appcreateddata') ? (
+                <Alert severity="warning">
+                  {t('photos:source.googlePicker.missingScope')}
+                </Alert>
+              ) : (
+                <>
+                  <Typography variant="body2" sx={{ mb: 1 }}>
+                    {t('photos:source.googlePicker.explain')}
+                  </Typography>
+                  {!pickerWaiting ? (
+                    <Button
+                      type="button"
+                      variant="contained"
+                      startIcon={<CloudUpload />}
+                      onClick={handleStartPicker}
+                    >
+                      {t('photos:source.googlePicker.pickPhotos')}
+                    </Button>
+                  ) : (
+                    <Box>
+                      <Alert severity="info" sx={{ mb: 1 }}>
+                        {popupBlocked && pickerUri ? (
+                          <>
+                            {t('photos:source.googlePicker.popupBlocked')}{' '}
+                            <a href={pickerUri} target="_blank" rel="noopener noreferrer">
+                              {t('photos:source.googlePicker.openManually')}
+                            </a>
+                          </>
+                        ) : (
+                          t('photos:source.googlePicker.waiting')
+                        )}
+                      </Alert>
+                      <Button type="button" onClick={handleCancelPicker}>
+                        {t('photos:source.googlePicker.cancel')}
+                      </Button>
+                    </Box>
+                  )}
+
+                  {pickerError && (
+                    <Alert severity="error" sx={{ mt: 2 }}>
+                      {pickerError}
+                    </Alert>
+                  )}
+                  {pickerResult && (
+                    <Alert
+                      severity={pickerResult.failed > 0 ? 'warning' : 'success'}
+                      sx={{ mt: 2 }}
+                    >
+                      {t('photos:source.googlePicker.result', pickerResult)}
+                    </Alert>
+                  )}
+
+                  <Box sx={{ mt: 3 }}>
+                    <Typography variant="subtitle2" gutterBottom>
+                      {t('photos:source.googlePicker.pickedTitle', { count: pickedItems.length })}
+                    </Typography>
+                    {pickedLoading ? (
+                      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+                        <CircularProgress size={20} />
+                      </Box>
+                    ) : pickedItems.length === 0 ? (
+                      <Typography variant="body2" color="text.secondary">
+                        {t('photos:source.googlePicker.pickedEmpty')}
+                      </Typography>
+                    ) : (
+                      <Box
+                        sx={{
+                          display: 'grid',
+                          gridTemplateColumns: 'repeat(auto-fill, minmax(80px, 1fr))',
+                          gap: 1
+                        }}
+                      >
+                        {pickedItems.map((item) => (
+                          <Box key={item.id} sx={{ position: 'relative' }}>
+                            <img
+                              src={`${API_BASE_URL}/api/photo-sources/${editingSource.id}/picked/${item.id}`}
+                              alt={item.filename || ''}
+                              style={{
+                                width: '100%',
+                                height: 80,
+                                objectFit: 'cover',
+                                borderRadius: 4,
+                                display: 'block'
+                              }}
+                            />
+                            <IconButton
+                              size="small"
+                              onClick={() => handleDeletePicked(item.id)}
+                              sx={{
+                                position: 'absolute',
+                                top: 2,
+                                right: 2,
+                                backgroundColor: 'rgba(0, 0, 0, 0.6)',
+                                color: 'white',
+                                '&:hover': { backgroundColor: 'rgba(0, 0, 0, 0.8)' }
+                              }}
+                            >
+                              <Delete fontSize="small" />
+                            </IconButton>
+                          </Box>
+                        ))}
+                      </Box>
+                    )}
+                  </Box>
+                </>
+              )}
+            </Box>
           )}
 
           {sourceForm.type === 'HomeGlowPhotos' && (

--- a/client/src/components/PhotoWidget.jsx
+++ b/client/src/components/PhotoWidget.jsx
@@ -4,6 +4,11 @@ import { Settings, Add, Delete, Edit, Refresh, ChevronLeft, ChevronRight, PlayAr
 import axios from 'axios';
 import { useTranslation } from 'react-i18next';
 import { API_BASE_URL } from '../utils/apiConfig.js';
+import {
+  parseDurationMs,
+  hasGooglePhotosPickerScope,
+  summarizePickerIngest,
+} from '../utils/googlePhotosPicker.js';
 
 const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
   const { t } = useTranslation(['photos', 'common']);
@@ -224,15 +229,6 @@ const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
     }
   };
 
-  // "5s" / "1799.969983s" → seconds as a number. Google returns picker
-  // pollingConfig values as duration strings, not numbers.
-  const parseDurationSeconds = (v) => {
-    if (typeof v === 'number' && Number.isFinite(v)) return v;
-    if (typeof v !== 'string') return null;
-    const m = v.match(/^([\d.]+)s?$/);
-    return m ? parseFloat(m[1]) : null;
-  };
-
   const stopPicker = () => {
     pickerActiveRef.current = false;
     if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
@@ -318,8 +314,8 @@ const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
       setPopupBlocked(true);
     }
 
-    const pollSecs = parseDurationSeconds(session.pollingConfig?.pollInterval) || 5;
-    const timeoutSecs = parseDurationSeconds(session.pollingConfig?.timeoutIn) || 1800;
+    const pollMs = Math.max(1000, parseDurationMs(session.pollingConfig?.pollInterval, 5000));
+    const timeoutMs = Math.max(1000, parseDurationMs(session.pollingConfig?.timeoutIn, 1800000));
     const sourceId = editingSource.id;
 
     pickerActiveRef.current = true;
@@ -335,14 +331,14 @@ const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
       } catch (error) {
         console.error('Error polling picker session:', error);
       }
-    }, Math.max(1, pollSecs) * 1000);
+    }, pollMs);
 
     pollTimeoutRef.current = setTimeout(() => {
       if (pickerActiveRef.current) {
         stopPicker();
         setPickerError(t('photos:source.googlePicker.timedOut'));
       }
-    }, Math.max(1, timeoutSecs) * 1000);
+    }, timeoutMs);
   };
 
   const handleCancelPicker = async () => {
@@ -808,7 +804,7 @@ const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
                 <Alert severity="warning">
                   {t('photos:source.googlePicker.noAccount')}
                 </Alert>
-              ) : !(googleStatus.account.scopes || '').includes('photoslibrary.readonly.appcreateddata') ? (
+              ) : !hasGooglePhotosPickerScope(googleStatus.account.scopes) ? (
                 <Alert severity="warning">
                   {t('photos:source.googlePicker.missingScope')}
                 </Alert>
@@ -851,14 +847,14 @@ const PhotoWidget = ({ refreshNonce = 0, isActive = true }) => {
                       {pickerError}
                     </Alert>
                   )}
-                  {pickerResult && (
-                    <Alert
-                      severity={pickerResult.failed > 0 ? 'warning' : 'success'}
-                      sx={{ mt: 2 }}
-                    >
-                      {t('photos:source.googlePicker.result', pickerResult)}
-                    </Alert>
-                  )}
+                  {pickerResult && (() => {
+                    const summary = summarizePickerIngest(pickerResult);
+                    return (
+                      <Alert severity={summary.severity} sx={{ mt: 2 }}>
+                        {t('photos:source.googlePicker.result', summary)}
+                      </Alert>
+                    );
+                  })()}
 
                   <Box sx={{ mt: 3 }}>
                     <Typography variant="subtitle2" gutterBottom>

--- a/client/src/i18n/locales/en/photos.json
+++ b/client/src/i18n/locales/en/photos.json
@@ -35,6 +35,7 @@
     "type": "Type",
     "immich": "Immich",
     "homeglow": "HomeGlow Photos",
+    "google": "Google Photos",
     "immichUrl": "Immich Server URL",
     "immichUrlPlaceholder": "Your Immich server URL",
     "apiKey": "API Key",
@@ -45,7 +46,23 @@
     "uploadExplain": "Upload photos directly from your device. They will be stored on your HomeGlow server and displayed in this widget.",
     "openUploadPage": "Open upload page",
     "mobileHint": "The upload page is mobile-friendly—open it on your phone to upload photos straight from your camera roll.",
-    "testConnection": "Test Connection"
+    "testConnection": "Test Connection",
+    "googlePicker": {
+      "explain": "Pick photos from your Google account. They will be downloaded to your HomeGlow server so they keep working even if the shared session expires.",
+      "pickPhotos": "Pick photos in Google Photos",
+      "waiting": "Waiting for you to choose photos in Google Photos…",
+      "popupBlocked": "Your browser blocked the Google Photos window.",
+      "openManually": "Open it manually",
+      "cancel": "Cancel",
+      "timedOut": "Timed out waiting for a Google Photos selection. You can try again.",
+      "startFailed": "Could not start a Google Photos picker session.",
+      "ingestFailed": "Could not download the photos you picked.",
+      "result": "Added {{added}}, skipped {{skipped}}, failed {{failed}} of {{total}}.",
+      "noAccount": "Connect a Google account first from the Admin Panel → Connections tab, then come back here.",
+      "missingScope": "This Google connection does not include Photos permission. Reconnect from Admin Panel → Connections with the Photos option enabled.",
+      "pickedTitle": "Picked photos ({{count}})",
+      "pickedEmpty": "No photos picked yet. Use the pick button above to choose some."
+    }
   },
   "confirm": {
     "deleteSource": "Are you sure you want to delete this photo source?"

--- a/client/src/i18n/locales/es/photos.json
+++ b/client/src/i18n/locales/es/photos.json
@@ -35,6 +35,7 @@
     "type": "Tipo",
     "immich": "Immich",
     "homeglow": "Fotos de HomeGlow",
+    "google": "Google Fotos",
     "immichUrl": "URL del servidor Immich",
     "immichUrlPlaceholder": "La URL de tu servidor Immich",
     "apiKey": "Clave de API",
@@ -45,7 +46,23 @@
     "uploadExplain": "Sube fotos directamente desde tu dispositivo. Se guardarán en tu servidor HomeGlow y se mostrarán en este widget.",
     "openUploadPage": "Abrir la página de subida",
     "mobileHint": "La página de subida está adaptada al móvil: ábrela en tu teléfono para subir fotos directamente desde tu galería.",
-    "testConnection": "Probar conexión"
+    "testConnection": "Probar conexión",
+    "googlePicker": {
+      "explain": "Elige fotos desde tu cuenta de Google. Se descargarán a tu servidor de HomeGlow para que sigan funcionando aunque caduque la sesión compartida.",
+      "pickPhotos": "Elegir fotos en Google Fotos",
+      "waiting": "Esperando a que elijas fotos en Google Fotos…",
+      "popupBlocked": "Tu navegador bloqueó la ventana de Google Fotos.",
+      "openManually": "Ábrela manualmente",
+      "cancel": "Cancelar",
+      "timedOut": "Se agotó el tiempo esperando tu selección en Google Fotos. Puedes intentarlo de nuevo.",
+      "startFailed": "No se pudo iniciar la sesión del selector de Google Fotos.",
+      "ingestFailed": "No se pudieron descargar las fotos que elegiste.",
+      "result": "Añadidas {{added}}, omitidas {{skipped}}, fallidas {{failed}} de {{total}}.",
+      "noAccount": "Primero conecta una cuenta de Google desde el Panel de administración → pestaña Conexiones y luego vuelve aquí.",
+      "missingScope": "Esta conexión de Google no incluye el permiso de Fotos. Vuelve a conectarla desde el Panel de administración → Conexiones con la opción de Fotos activada.",
+      "pickedTitle": "Fotos elegidas ({{count}})",
+      "pickedEmpty": "Aún no has elegido fotos. Usa el botón de arriba para elegir algunas."
+    }
   },
   "confirm": {
     "deleteSource": "¿Seguro que quieres eliminar esta fuente de fotos?"

--- a/client/src/utils/googlePhotosPicker.js
+++ b/client/src/utils/googlePhotosPicker.js
@@ -1,0 +1,81 @@
+// Pure helpers for the Google Photos picker flow in PhotoWidget.
+//
+// Everything that touches axios, timers, or React state lives in the
+// component; anything that can be a plain data-in / data-out decision lives
+// here so it can be tested without a browser.
+
+// Google's picker session response returns pollingConfig.pollInterval and
+// pollingConfig.timeoutIn as protobuf duration strings ("5s", "1799.969983s"),
+// not numbers. Accept a number, a duration string with or without the trailing
+// "s", or an already-fractional value; on anything else fall back rather than
+// return NaN — a NaN passed to setTimeout is silently coerced to 1ms and would
+// hammer the polling endpoint or fire the timeout instantly.
+const DURATION_PATTERN = /^\s*(\d+(?:\.\d+)?|\.\d+)\s*s?\s*$/;
+
+export const REQUIRED_GOOGLE_PHOTOS_SCOPE = 'photoslibrary.readonly.appcreateddata';
+
+/**
+ * Parse a Google duration string ("5s", "1799.969983s") or bare number of
+ * seconds into a millisecond count. Returns `fallbackMs` for anything that
+ * cannot be parsed (undefined, null, empty, malformed, negative, non-finite).
+ */
+export const parseDurationMs = (value, fallbackMs) => {
+    const seconds = parseDurationSeconds(value);
+    if (seconds === null || seconds < 0) return fallbackMs;
+    return Math.round(seconds * 1000);
+};
+
+/**
+ * Parse a Google duration string into a number of seconds. Returns null when
+ * the value is missing or malformed; callers decide what to substitute.
+ */
+export const parseDurationSeconds = (value) => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+    if (typeof value !== 'string') return null;
+    const match = value.match(DURATION_PATTERN);
+    if (!match) return null;
+    const parsed = parseFloat(match[1]);
+    return Number.isFinite(parsed) ? parsed : null;
+};
+
+/**
+ * Does the space-separated `scopes` string include the picker's required
+ * Photos scope? Splits on whitespace so a scope that merely contains the name
+ * as a substring (e.g. a hypothetical `photoslibrary.readonly.appcreateddata.extended`)
+ * does not produce a false positive; accepts either the bare scope name or
+ * the full `https://www.googleapis.com/auth/…` form Google actually returns.
+ */
+export const hasGooglePhotosPickerScope = (scopes) => {
+    if (typeof scopes !== 'string' || scopes.length === 0) return false;
+    const suffix = `/${REQUIRED_GOOGLE_PHOTOS_SCOPE}`;
+    return scopes.split(/\s+/).some((token) => (
+        token === REQUIRED_GOOGLE_PHOTOS_SCOPE || token.endsWith(suffix)
+    ));
+};
+
+/**
+ * Reduce the server's ingest result ({added, skipped, failed, total}) into
+ * the pieces the UI needs. `severity` drives the Alert colour — a run with
+ * any `failed` count must not be presented as a clean success, even if some
+ * items were added.
+ */
+export const summarizePickerIngest = (result) => {
+    const added = toCount(result?.added);
+    const skipped = toCount(result?.skipped);
+    const failed = toCount(result?.failed);
+    const total = toCount(result?.total);
+    return {
+        added,
+        skipped,
+        failed,
+        total,
+        severity: failed > 0 ? 'warning' : 'success',
+    };
+};
+
+const toCount = (value) => {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return 0;
+    return Math.trunc(value);
+};

--- a/client/src/utils/googlePhotosPicker.test.js
+++ b/client/src/utils/googlePhotosPicker.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+    REQUIRED_GOOGLE_PHOTOS_SCOPE,
+    parseDurationMs,
+    parseDurationSeconds,
+    hasGooglePhotosPickerScope,
+    summarizePickerIngest,
+} from './googlePhotosPicker.js';
+
+describe('parseDurationSeconds', () => {
+    it('parses an integer-second duration string', () => {
+        expect(parseDurationSeconds('5s')).toBe(5);
+    });
+
+    it('parses a fractional-second duration string', () => {
+        expect(parseDurationSeconds('1799.969983s')).toBeCloseTo(1799.969983, 6);
+    });
+
+    it('accepts a value with no unit', () => {
+        expect(parseDurationSeconds('12')).toBe(12);
+    });
+
+    it('accepts a bare finite number', () => {
+        expect(parseDurationSeconds(7)).toBe(7);
+    });
+
+    it('rejects non-finite numbers', () => {
+        expect(parseDurationSeconds(NaN)).toBeNull();
+        expect(parseDurationSeconds(Infinity)).toBeNull();
+    });
+
+    it('returns null for missing, empty, or malformed input', () => {
+        expect(parseDurationSeconds(undefined)).toBeNull();
+        expect(parseDurationSeconds(null)).toBeNull();
+        expect(parseDurationSeconds('')).toBeNull();
+        expect(parseDurationSeconds('abc')).toBeNull();
+        expect(parseDurationSeconds('5m')).toBeNull();
+        expect(parseDurationSeconds({})).toBeNull();
+    });
+});
+
+describe('parseDurationMs', () => {
+    it('converts an integer-second string to milliseconds', () => {
+        expect(parseDurationMs('5s', 1)).toBe(5000);
+    });
+
+    it('converts a fractional-second string to milliseconds', () => {
+        // 1799.969983 * 1000 rounds to 1799970 rather than losing the fraction.
+        expect(parseDurationMs('1799.969983s', 1)).toBe(1799970);
+    });
+
+    it('treats a bare number of seconds correctly', () => {
+        expect(parseDurationMs(2, 1)).toBe(2000);
+    });
+
+    it('returns the fallback for a missing value rather than NaN', () => {
+        // NaN passed to setTimeout is silently coerced to 1ms — the fallback
+        // exists specifically to keep that from happening.
+        expect(parseDurationMs(undefined, 5000)).toBe(5000);
+        expect(parseDurationMs(null, 5000)).toBe(5000);
+    });
+
+    it('returns the fallback for malformed input rather than NaN', () => {
+        expect(parseDurationMs('not-a-duration', 1800000)).toBe(1800000);
+        expect(parseDurationMs('5m', 1800000)).toBe(1800000);
+        expect(parseDurationMs('', 42)).toBe(42);
+    });
+
+    it('returns the fallback for negative durations', () => {
+        expect(parseDurationMs('-5s', 5000)).toBe(5000);
+        expect(parseDurationMs(-2, 5000)).toBe(5000);
+    });
+
+    it('never returns NaN even when the fallback is not supplied', () => {
+        expect(Number.isNaN(parseDurationMs(undefined))).toBe(false);
+        expect(parseDurationMs('bogus')).toBeUndefined();
+    });
+});
+
+describe('hasGooglePhotosPickerScope', () => {
+    const fullScopeUrl = `https://www.googleapis.com/auth/${REQUIRED_GOOGLE_PHOTOS_SCOPE}`;
+
+    it('returns true for the full URL-form scope Google actually returns', () => {
+        const scopes = `openid email ${fullScopeUrl}`;
+        expect(hasGooglePhotosPickerScope(scopes)).toBe(true);
+    });
+
+    it('returns true for the bare scope name on its own', () => {
+        expect(hasGooglePhotosPickerScope(REQUIRED_GOOGLE_PHOTOS_SCOPE)).toBe(true);
+    });
+
+    it('returns false when only the deprecated broader scope is present', () => {
+        // The 2025-03-31 replacement scope has to be granted specifically —
+        // the old `photoslibrary.readonly` on its own is not sufficient.
+        const scopes = 'openid https://www.googleapis.com/auth/photoslibrary.readonly';
+        expect(hasGooglePhotosPickerScope(scopes)).toBe(false);
+    });
+
+    it('rejects a scope that merely contains the required name as a substring', () => {
+        // Guards against a naive `.includes(name)` check being fooled by a
+        // scope whose name happens to end in a longer suffix.
+        const scopes = 'https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata.extended';
+        expect(hasGooglePhotosPickerScope(scopes)).toBe(false);
+    });
+
+    it('rejects a scope with the required name as a prefix segment', () => {
+        const scopes = 'photoslibrary.readonly.appcreateddataX';
+        expect(hasGooglePhotosPickerScope(scopes)).toBe(false);
+    });
+
+    it('handles missing, empty, or non-string inputs', () => {
+        expect(hasGooglePhotosPickerScope(undefined)).toBe(false);
+        expect(hasGooglePhotosPickerScope(null)).toBe(false);
+        expect(hasGooglePhotosPickerScope('')).toBe(false);
+        expect(hasGooglePhotosPickerScope([REQUIRED_GOOGLE_PHOTOS_SCOPE])).toBe(false);
+    });
+
+    it('tolerates any whitespace between scopes', () => {
+        const scopes = `openid\t${fullScopeUrl}\nemail`;
+        expect(hasGooglePhotosPickerScope(scopes)).toBe(true);
+    });
+});
+
+describe('summarizePickerIngest', () => {
+    it('marks a clean run as success', () => {
+        const summary = summarizePickerIngest({ added: 4, skipped: 0, failed: 0, total: 4 });
+        expect(summary).toEqual({ added: 4, skipped: 0, failed: 0, total: 4, severity: 'success' });
+    });
+
+    it('marks any run with a failure as warning, even when items were added', () => {
+        // A partial success must not be rendered as a clean success — a red
+        // photo the user picked and expected to see is a real failure.
+        const summary = summarizePickerIngest({ added: 3, skipped: 1, failed: 2, total: 6 });
+        expect(summary.severity).toBe('warning');
+    });
+
+    it('marks an all-skipped run as success', () => {
+        const summary = summarizePickerIngest({ added: 0, skipped: 5, failed: 0, total: 5 });
+        expect(summary.severity).toBe('success');
+    });
+
+    it('coerces missing fields to zero so the template never renders undefined', () => {
+        const summary = summarizePickerIngest({});
+        expect(summary).toEqual({ added: 0, skipped: 0, failed: 0, total: 0, severity: 'success' });
+    });
+
+    it('coerces negative or non-numeric counts to zero', () => {
+        const summary = summarizePickerIngest({
+            added: -1,
+            skipped: 'two',
+            failed: null,
+            total: NaN,
+        });
+        expect(summary).toEqual({ added: 0, skipped: 0, failed: 0, total: 0, severity: 'success' });
+    });
+
+    it('truncates fractional counts rather than passing floats to the UI', () => {
+        const summary = summarizePickerIngest({ added: 3.9, skipped: 0, failed: 0, total: 3.9 });
+        expect(summary.added).toBe(3);
+        expect(summary.total).toBe(3);
+    });
+
+    it('is safe on a null/undefined result', () => {
+        expect(summarizePickerIngest(null).severity).toBe('success');
+        expect(summarizePickerIngest(undefined).added).toBe(0);
+    });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ stays relevant.
 - [Getting Started (Local Dev)](guides/getting-started.md)
 - [Deployment](guides/deployment.md) — Docker Compose, Portainer, Proxmox LXC, and updating.
 - [Demo Mode](guides/demo-mode.md) — run a public, self-resetting showcase instance with sample data.
+- [Google Integration](guides/google-integration.md) — connect Google Calendar and Google Photos: OAuth client, the two APIs to enable, and what verification does and does not mean.
 - [Configuration](reference/configuration.md) — environment variables and admin-panel settings.
 - [Custom Widget Development](guides/custom-widgets.md) — build and publish your own HTML widgets.
 - [Plugin Development](guides/plugin-development.md) — the full guide: manifest, storage, settings, events, reactions, and a complete worked example.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ stays relevant.
 - [Getting Started (Local Dev)](guides/getting-started.md)
 - [Deployment](guides/deployment.md) — Docker Compose, Portainer, Proxmox LXC, and updating.
 - [Demo Mode](guides/demo-mode.md) — run a public, self-resetting showcase instance with sample data.
-- [Google Integration](guides/google-integration.md) — connect Google Calendar and Google Photos: OAuth client, the two APIs to enable, and what verification does and does not mean.
+- [Google Integration](guides/google-integration.md) — connect Google Calendar and Google Photos: OAuth client, redirect URI, which APIs to enable, and what verification does and does not mean.
 - [Configuration](reference/configuration.md) — environment variables and admin-panel settings.
 - [Custom Widget Development](guides/custom-widgets.md) — build and publish your own HTML widgets.
 - [Plugin Development](guides/plugin-development.md) — the full guide: manifest, storage, settings, events, reactions, and a complete worked example.

--- a/docs/guides/google-integration.md
+++ b/docs/guides/google-integration.md
@@ -1,0 +1,129 @@
+# Google Integration
+
+Connecting a Google account gives HomeGlow two things:
+
+- **Google Calendar** — two-way sync. Events from the calendars you choose appear
+  in the Calendar widget, and events you create on the wall display are written
+  back to Google.
+- **Google Photos** — photos you pick appear in the Photo widget slideshow.
+
+Both run through a **Google Cloud OAuth client that you create and own**. HomeGlow
+ships no shared credentials, so nothing about your calendar or photos passes
+through anyone else's project.
+
+> **This takes about ten minutes**, and most of it is in the Google Cloud Console
+> rather than HomeGlow. The two steps people miss are **enabling the APIs**
+> (§2 — there are *two* of them) and **the redirect URI scheme** (§3).
+
+## 1. Create the OAuth client
+
+In the [Google Cloud Console](https://console.cloud.google.com/):
+
+1. Create a project, or pick an existing one.
+2. **APIs & Services → OAuth consent screen.** Choose **External**, fill in the
+   app name and your email. You do **not** need to submit for verification —
+   see [Verification](#verification-and-what-it-does-not-mean) below.
+3. **APIs & Services → Credentials → Create Credentials → OAuth client ID.**
+   Application type: **Web application**.
+4. Leave the redirect URI blank for now — HomeGlow will tell you exactly what to
+   paste in §3.
+5. Keep the **Client ID** and **Client secret**.
+
+## 2. Enable the APIs — both of them
+
+**This is the step that most often goes wrong**, because nothing fails until you
+try to use the feature, and then the error appears in a server log rather than on
+screen.
+
+Under **APIs & Services → Library**, enable:
+
+| API | Needed for |
+|---|---|
+| **Google Calendar API** | the Calendar widget |
+| **Google Photos Library API** | the Photos widget |
+| **Google Photos Picker API** | the Photos widget — **a separate API from the one above** |
+
+Photos needs **both** of the last two. Enabling only the Library API leaves photo
+picking failing with a 403 that names the Picker API. Google caches the
+disabled state briefly, so give it a minute or two before retrying.
+
+## 3. Give HomeGlow the credentials
+
+**Admin Panel → Connections → Google.**
+
+1. Paste the **Client ID** and **Client secret**, then **Save Credentials**.
+2. Look at the **Redirect URI** field. HomeGlow derives it from the address you
+   are using, and there is a copy button beside it. **Copy that exact value** and
+   add it to your OAuth client in the Cloud Console under *Authorized redirect
+   URIs*. It must match character for character and must end in
+   `/api/connections/google/callback`.
+
+> **If the Redirect URI shows `http://` but you reach HomeGlow over HTTPS**, the
+> field is editable — correct the scheme by hand and save. Google refuses any
+> non-`localhost` redirect URI that is not HTTPS, so an `http://` value cannot be
+> registered at all, and registering the `https://` form while HomeGlow sends
+> `http://` produces `redirect_uri_mismatch`. This happens when TLS is terminated
+> by a reverse proxy in front of the container.
+
+Plain HTTP is fine without any of this if you reach HomeGlow at
+`http://localhost:<port>` — Google exempts loopback addresses.
+
+## 4. Authorize
+
+Click **Authorize with Google** and complete the consent screen in the popup.
+
+Because the app is unverified, Google shows an **"unverified app"** warning. Choose
+**Advanced → Go to \<your app\> (unsafe)** to continue. That warning is about
+Google not having reviewed *your own* OAuth client; the credentials never leave
+your project.
+
+Once connected, the panel shows the account and what it granted.
+
+## 5. Calendars
+
+**Admin Panel → Calendar sources → Add source → Google.** Pick which of the
+account's calendars to show; each keeps its own colour in the Calendar widget.
+Calendars shared with the account appear alongside its own.
+
+## 6. Photos
+
+**Photo widget → settings → Add source → type `Google Photos`.** Save the source
+first, then use **Choose photos**. That opens Google's own picker in a new tab,
+where you select the photos you want. HomeGlow polls until you are done, then
+downloads the selected photos and lists them, with a delete button per photo.
+
+> **Why a picker rather than browsing your albums?** Google removed the broad
+> `photoslibrary.readonly` scope on 2025-03-31. The replacement scope only exposes
+> media that the app itself created — which for HomeGlow is nothing. Picking is
+> now the supported way for an app to reach photos you already have, and it means
+> HomeGlow only ever sees the photos you explicitly hand it.
+
+## Verification, and what it does not mean
+
+Google requires apps requesting *sensitive* or *restricted* scopes to pass
+verification **before publishing them to the general public**. A self-hosted
+HomeGlow serving one household is not that: you created the OAuth client, you own
+the project, and you are its only user. The unverified-app warning in §4 is the
+normal and expected path.
+
+Two things do change under verification pressure, and both are worth knowing:
+
+- **Accounts enrolled in [Google's Advanced Protection Program](https://landing.google.com/advancedprotection/)
+  cannot use unverified apps at all.** Authorization fails with
+  `Error 400: policy_enforced`. This is **not** specific to Photos — an
+  APP-enrolled account is refused even for Calendar alone. Use a different
+  account for the display, or leave the program.
+- **Publishing status affects token lifetime.** An app left in *Testing* issues
+  refresh tokens that expire after **7 days**, which will disconnect your display
+  every week. Set the consent screen to **In production** (this does not require
+  verification) so the connection persists.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Error 400: redirect_uri_mismatch` | The Redirect URI in HomeGlow and the one registered in the Cloud Console differ. Compare them character for character, including the scheme — see §3. |
+| `Error 400: policy_enforced` | The Google account is enrolled in Advanced Protection, which refuses unverified apps. Use a different account. |
+| Photo picking fails, or the photo list stays empty | One of the two Photos APIs is not enabled — see §2. The Picker API is separate from the Library API. |
+| Connection drops every week | The OAuth consent screen is still in *Testing*. Set it to *In production*. |
+| Calendar events do not appear | Check the calendar is selected in **Calendar sources**, and that the Google Calendar API is enabled. |

--- a/docs/guides/google-integration.md
+++ b/docs/guides/google-integration.md
@@ -12,8 +12,9 @@ ships no shared credentials, so nothing about your calendar or photos passes
 through anyone else's project.
 
 > **This takes about ten minutes**, and most of it is in the Google Cloud Console
-> rather than HomeGlow. The two steps people miss are **enabling the APIs**
-> (§2 — there are *two* of them) and **the redirect URI scheme** (§3).
+> rather than HomeGlow. The two steps people miss are **enabling the right
+> Photos API** (§2 — two have nearly identical names) and **the redirect URI
+> scheme** (§3).
 
 ## 1. Create the OAuth client
 
@@ -40,12 +41,16 @@ Under **APIs & Services → Library**, enable:
 | API | Needed for |
 |---|---|
 | **Google Calendar API** | the Calendar widget |
-| **Google Photos Library API** | the Photos widget |
-| **Google Photos Picker API** | the Photos widget — **a separate API from the one above** |
+| **Google Photos Picker API** | the Photo widget |
 
-Photos needs **both** of the last two. Enabling only the Library API leaves photo
-picking failing with a 403 that names the Picker API. Google caches the
-disabled state briefly, so give it a minute or two before retrying.
+**Enable the Picker API, not the Library API.** The two have confusingly similar
+names and it is easy to enable the wrong one: picking photos goes through
+`photospicker.googleapis.com`, and downloads come straight from the URL the picker
+hands back. The older `photoslibrary.googleapis.com` is not used by this flow.
+
+If you enable the wrong one, picking fails with a 403 whose message names the API
+you are missing — read it rather than guessing. Google caches the disabled state
+briefly, so give it a minute or two before retrying.
 
 ## 3. Give HomeGlow the credentials
 
@@ -81,14 +86,15 @@ Once connected, the panel shows the account and what it granted.
 
 ## 5. Calendars
 
-**Admin Panel → Calendar sources → Add source → Google.** Pick which of the
-account's calendars to show; each keeps its own colour in the Calendar widget.
-Calendars shared with the account appear alongside its own.
+**Calendar widget → settings → Add source → Google.** Calendar sources are
+configured on the widget itself, not in the Admin Panel — the same place photo
+sources live. Pick which of the account's calendars to show; each keeps its own
+colour. Calendars shared with the account appear alongside its own.
 
 ## 6. Photos
 
 **Photo widget → settings → Add source → type `Google Photos`.** Save the source
-first, then use **Choose photos**. That opens Google's own picker in a new tab,
+first, then use **Pick photos in Google Photos**. That opens Google's own picker in a new tab,
 where you select the photos you want. HomeGlow polls until you are done, then
 downloads the selected photos and lists them, with a delete button per photo.
 
@@ -124,6 +130,6 @@ Two things do change under verification pressure, and both are worth knowing:
 |---|---|
 | `Error 400: redirect_uri_mismatch` | The Redirect URI in HomeGlow and the one registered in the Cloud Console differ. Compare them character for character, including the scheme — see §3. |
 | `Error 400: policy_enforced` | The Google account is enrolled in Advanced Protection, which refuses unverified apps. Use a different account. |
-| Photo picking fails, or the photo list stays empty | One of the two Photos APIs is not enabled — see §2. The Picker API is separate from the Library API. |
+| Photo picking fails with a 403 | The **Photos Picker API** is not enabled — see §2. Note it is a different API from the similarly named Photos Library API; the error message names the one you are missing. |
 | Connection drops every week | The OAuth consent screen is still in *Testing*. Set it to *In production*. |
 | Calendar events do not appear | Check the calendar is selected in **Calendar sources**, and that the Google Calendar API is enabled. |

--- a/docs/guides/google-integration.md
+++ b/docs/guides/google-integration.md
@@ -30,11 +30,12 @@ In the [Google Cloud Console](https://console.cloud.google.com/):
    paste in §3.
 5. Keep the **Client ID** and **Client secret**.
 
-## 2. Enable the APIs — both of them
+## 2. Enable the APIs
 
-**This is the step that most often goes wrong**, because nothing fails until you
-try to use the feature, and then the error appears in a server log rather than on
-screen.
+**This is the step that most often goes wrong**, because nothing fails at setup
+time — the APIs are only touched once you actually use a widget. When it does
+fail, HomeGlow shows Google's own error, which names the missing API and links
+straight to the console page that enables it.
 
 Under **APIs & Services → Library**, enable:
 
@@ -94,8 +95,8 @@ colour. Calendars shared with the account appear alongside its own.
 ## 6. Photos
 
 **Photo widget → settings → Add source → type `Google Photos`.** Save the source
-first, then use **Pick photos in Google Photos**. That opens Google's own picker in a new tab,
-where you select the photos you want. HomeGlow polls until you are done, then
+first, then use **Pick photos in Google Photos**. That opens Google's own picker
+in a new tab, where you select the photos you want. HomeGlow polls until you are done, then
 downloads the selected photos and lists them, with a delete button per photo.
 
 > **Why a picker rather than browsing your albums?** Google removed the broad


### PR DESCRIPTION
Google Photos is implemented on the server — source type, picker sessions, ingest, local storage, media serving — and there is no way to reach any of it from the UI. `GooglePhotos` is not offered in the photo-source type dropdown, and the strings `GooglePhotos` and `picker-session` appear **nowhere in `client/src/`**. The feature is finished and has no front door.

This adds the missing configuration UI. **No server changes** — every endpoint used here already exists.

## The gap

`PhotoWidget.jsx` offers exactly two source types:

```jsx
<MenuItem value="Immich">{t('photos:source.immich')}</MenuItem>
<MenuItem value="HomeGlowPhotos">{t('photos:source.homeglow')}</MenuItem>
```

Meanwhile `server/index.js:5397` accepts `['Immich', 'GooglePhotos', 'HomeGlowPhotos']`, `services/googlePhotosPicker.js` implements sessions and downloads, `schema10-googlePhotosPicker` creates `google_picked_media`, and four picker-session routes are live and documented in `docs/reference/backend-api.md`.

Driving those endpoints by hand against a real Google account works end to end:

```
POST /api/photo-sources                     {"type":"GooglePhotos"}  -> {"id":1,"success":true}
POST /api/photo-sources/1/picker-session    -> sessionId, pickerUri, mediaItemsSet false
     (user picks 3 photos in Google's picker)
GET  /api/photo-sources/1/picker-session    -> mediaItemsSet true
POST /api/photo-sources/1/picker-session/ingest  -> {"added":3,"skipped":0,"failed":0,"total":3}
GET  /api/photo-sources/1/picked/1          -> HTTP 200  image/jpeg  502516 bytes
```

The widget then renders them correctly with no changes — the slideshow path is already source-type agnostic. Only the configuration surface was missing.

## Change

**`GooglePhotos` in the source-type dropdown**, and a matching branch in the source dialog. It needs none of the Immich fields — just a name.

**The picker flow.** For a saved source: create a session, open Google's `pickerUri` in a new tab, poll at the server-supplied `pollInterval` until `mediaItemsSet`, then ingest and refresh. `pollInterval` and `timeoutIn` are duration strings (`"5s"`), so they are parsed rather than used as numbers. Polling stops at `timeoutIn`, on cancel, and on unmount; cancelling deletes the session server-side.

Following the existing `HomeGlowPhotos` precedent, a source must be saved before photos can be picked — a picker session is created against a source id — so an unsaved source shows a save-first hint rather than a dead button.

**Picked-media list** with thumbnails, a count, and per-item delete, against the existing `…/picked` routes.

**Preconditions surfaced as guidance, not failures.** If no Google account is connected, or the connected account did not grant the Photos scopes, the panel says so and points at *Admin Panel → Connections*. It does not offer a button that would 403, and it does not try to start an OAuth flow from inside the Photos widget.

**i18n** — every added string is a key in the `photos` namespace, present in both `en` and `es`. `npm run check:i18n` reports 715/715, 100%.

**Tests.** The picker's pure decisions are extracted into `client/src/utils/googlePhotosPicker.js` and covered by `googlePhotosPicker.test.js`, following this project's convention that client tests target `src/utils/` — duration-string parsing (`"5s"`, `"1799.969983s"`, malformed, missing), the Photos scope check including substring near-misses, and ingest summarisation. A malformed `pollInterval` previously would have produced `NaN`, which `setTimeout` silently coerces to 1 ms — that now falls back instead.

## Docs

Adds `docs/guides/google-integration.md`. There was no Google setup documentation of any kind, and two steps fail quietly enough to cost real time:

- The **Photos Picker API** is what this flow needs (`photospicker.googleapis.com`). It is easy to enable the similarly named Photos Library API instead — that one is only reached by `listAlbums`, which no client code calls.
- Behind a TLS-terminating reverse proxy the derived redirect URI can come back `http://`, which Google will not accept for a non-`localhost` address. The field is editable — the guide says so and explains why.

It also records that an account enrolled in Advanced Protection cannot use an unverified app at all (Calendar included, not just Photos), and that leaving the consent screen in *Testing* expires refresh tokens after 7 days — which silently disconnects a wall display every week.

## Testing

Built and deployed to a TLS-terminated instance running this branch, with a real Google account and real photos. Session creation, selection in Google's picker, ingest, thumbnail rendering, per-item delete, the empty state, the no-account and missing-scope guidance, cancel-stops-polling, and closing the dialog mid-poll leaving no stray ingest — all exercised through the UI.

Suites run on Node 20 to match `ci-tests.yml`: backend **180 passing**, frontend **106 passing**, `check:i18n` 715/715, client build clean.

Note the picker window uses `window.open(uri, '_blank')` with `opener` nulled afterwards rather than the `noopener` feature string: per spec `noopener` always returns `null`, which would make popup-blocked detection fire on every call.
