### PR TITLE
Validate device names on rename so users don't brick a device profile

### DIFF
--- a/client/src/components/AdminPanel.jsx
+++ b/client/src/components/AdminPanel.jsx
@@ -69,7 +69,7 @@ import {
 import ColorPickerPopover from './ColorPickerPopover';
 import axios from 'axios';
 import { API_BASE_URL } from '../utils/apiConfig.js';
-import { getDeviceApiBase, getDeviceName, setDeviceName } from '../utils/deviceName.js';
+import { getDeviceApiBase, getDeviceName, setDeviceName, isValidDeviceName } from '../utils/deviceName.js';
 import PinModal from './PinModal';
 import ChoreSchedulesTab from './ChoreSchedulesTab';
 import ChoreHistoryTab from './ChoreHistoryTab';
@@ -1194,8 +1194,8 @@ const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
 
   const confirmRenameDevice = async () => {
     const nextName = (renameDeviceDialog.newName || '').trim();
-    if (!nextName) {
-      setRenameDeviceDialog(prev => ({ ...prev, error: 'Device Name is required.' }));
+    if (!isValidDeviceName(nextName)) {
+      setRenameDeviceDialog(prev => ({ ...prev, error: t('admin:devices.nameRule') }));
       return;
     }
 
@@ -4098,7 +4098,11 @@ const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
             fullWidth
             label={t('admin:devices.newName')}
             value={renameDeviceDialog.newName}
-            onChange={(e) => setRenameDeviceDialog(prev => ({ ...prev, newName: e.target.value, error: '' }))}
+            onChange={(e) => {
+              const val = e.target.value;
+              const validationError = isValidDeviceName(val) ? '' : t('admin:devices.nameRule');
+              setRenameDeviceDialog(prev => ({ ...prev, newName: val, error: validationError }));
+            }}
             error={Boolean(renameDeviceDialog.error)}
             helperText={renameDeviceDialog.error || 'This updates the current device name in both server and local storage.'}
             sx={{ mt: 1 }}
@@ -4109,7 +4113,12 @@ const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
           <Button onClick={() => setRenameDeviceDialog({ open: false, currentName: '', newName: '', error: '' })} variant="outlined">
             {t('common:actions.cancel')}
           </Button>
-          <Button onClick={confirmRenameDevice} variant="contained" startIcon={<Save />}>
+          <Button
+            onClick={confirmRenameDevice}
+            variant="contained"
+            startIcon={<Save />}
+            disabled={!isValidDeviceName((renameDeviceDialog.newName || '').trim())}
+          >
             {t('admin:devices.saveName')}
           </Button>
         </DialogActions>

--- a/client/src/i18n/locales/en/admin.json
+++ b/client/src/i18n/locales/en/admin.json
@@ -182,7 +182,8 @@
     "confirmCopy": "Confirm Copy",
     "renameTitle": "Rename Current Device Name",
     "newName": "New Device Name",
-    "saveName": "Save Name"
+    "saveName": "Save Name",
+    "nameRule": "Name must be 1–64 characters, contain at least one letter or digit, and may only include letters, digits, spaces, and _ - . ' ( )."
   },
   "colors": {
     "heading": "Accent Colors",

--- a/client/src/i18n/locales/es/admin.json
+++ b/client/src/i18n/locales/es/admin.json
@@ -182,7 +182,8 @@
     "confirmCopy": "Confirmar la copia",
     "renameTitle": "Cambiar el nombre del dispositivo actual",
     "newName": "Nuevo nombre del dispositivo",
-    "saveName": "Guardar el nombre"
+    "saveName": "Guardar el nombre",
+    "nameRule": "El nombre debe tener entre 1 y 64 caracteres, contener al menos una letra o dígito, y solo puede incluir letras, dígitos, espacios y _ - . ' ( )."
   },
   "colors": {
     "heading": "Colores de acento",

--- a/client/src/utils/deviceName.js
+++ b/client/src/utils/deviceName.js
@@ -1,4 +1,40 @@
+// Mirror of server/utils/deviceName.js. The server 400 is a backstop —
+// this file makes the client show the rule up-front so users see the
+// constraint the moment they type an invalid character in the rename
+// dialog, not after they submit.
+//
+// Rules must match server exactly:
+//   - allow-list of \p{L} \p{N} space _ - . ' ( )  (Unicode letters/digits
+//     plus a small set of URL-safe punctuation)
+//   - 1..64 characters after NFC-normalising and trimming
+//   - must contain at least one letter or digit (no pure-punctuation names)
+//   - must not contain '..'  (path-traversal shaped)
+//   - non-string inputs return false (matches server typeof guard)
+//
+// getDeviceName still returns exactly what is stored in localStorage —
+// no rewriting, no normalising on read. The validator runs only where a
+// human chooses a new name (rename dialog in AdminPanel).
+
 const DEVICE_NAME_STORAGE_KEY = 'homeglow_device_name';
+
+const DEVICE_NAME_ALLOWED = /^[\p{L}\p{N} _\-.'()]+$/u;
+const DEVICE_NAME_HAS_ALNUM = /[\p{L}\p{N}]/u;
+const DEVICE_NAME_MAX_LENGTH = 64;
+
+export const normalizeDeviceName = (raw) => {
+    if (typeof raw !== 'string') return '';
+    return raw.normalize('NFC').trim();
+};
+
+export const isValidDeviceName = (name) => {
+    if (typeof name !== 'string') return false;
+    const normalized = normalizeDeviceName(name);
+    if (normalized.length < 1 || normalized.length > DEVICE_NAME_MAX_LENGTH) return false;
+    if (normalized.includes('..')) return false;
+    if (!DEVICE_NAME_ALLOWED.test(normalized)) return false;
+    if (!DEVICE_NAME_HAS_ALNUM.test(normalized)) return false;
+    return true;
+};
 
 const generateDeviceName = () => {
     if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {

--- a/client/src/utils/deviceName.test.js
+++ b/client/src/utils/deviceName.test.js
@@ -1,5 +1,16 @@
+// Mirrors server/tests/deviceName.test.js. Both suites cover the same
+// cases so the two implementations cannot silently drift — a rule
+// change on one side that isn't ported to the other will show up as a
+// failing case in the mirror suite.
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { getDeviceName, setDeviceName, getDeviceApiBase } from './deviceName.js';
+import {
+    getDeviceName,
+    setDeviceName,
+    getDeviceApiBase,
+    isValidDeviceName,
+    normalizeDeviceName,
+} from './deviceName.js';
 
 function createLocalStorageMock() {
     const store = new Map();
@@ -51,6 +62,15 @@ describe('deviceName utilities', () => {
         expect(randomUuidSpy).not.toHaveBeenCalled();
     });
 
+    it('getDeviceName returns exactly what is stored, without rewriting', () => {
+        // The stored value may pre-date the current validation rule (e.g. a
+        // legacy name with '/' in it). getDeviceName must not mutate it —
+        // the client's identity is that string, whatever it is.
+        globalThis.localStorage.setItem('homeglow_device_name', 'Kitchen/Display');
+        expect(getDeviceName()).toBe('Kitchen/Display');
+        expect(globalThis.localStorage.getItem('homeglow_device_name')).toBe('Kitchen/Display');
+    });
+
     it('setDeviceName updates localStorage key', () => {
         setDeviceName('kitchen-hub');
 
@@ -63,5 +83,85 @@ describe('deviceName utilities', () => {
         const apiBase = getDeviceApiBase('http://localhost:5001');
 
         expect(apiBase).toBe('http://localhost:5001/api/devices/Kitchen%20Display%2FWest');
+    });
+});
+
+describe('isValidDeviceName', () => {
+    it('accepts common human-picked names', () => {
+        expect(isValidDeviceName('Kitchen Display')).toBe(true);
+        expect(isValidDeviceName("Nan's iPad")).toBe(true);
+        expect(isValidDeviceName('Playroom (up)')).toBe(true);
+        expect(isValidDeviceName('José')).toBe(true);
+        expect(isValidDeviceName('Kitchen_Hub-2')).toBe(true);
+    });
+
+    it('accepts a name that is exactly 64 characters long', () => {
+        expect(isValidDeviceName('a'.repeat(64))).toBe(true);
+    });
+
+    it('rejects URL-meaningful characters', () => {
+        expect(isValidDeviceName('a/b')).toBe(false);
+        expect(isValidDeviceName('a\\b')).toBe(false);
+        expect(isValidDeviceName('a?b')).toBe(false);
+        expect(isValidDeviceName('a#b')).toBe(false);
+        expect(isValidDeviceName('a%b')).toBe(false);
+        expect(isValidDeviceName('a&b')).toBe(false);
+        expect(isValidDeviceName('a+b')).toBe(false);
+        expect(isValidDeviceName('a:b')).toBe(false);
+        expect(isValidDeviceName('a@b')).toBe(false);
+    });
+
+    it('rejects path-traversal-shaped inputs', () => {
+        expect(isValidDeviceName('../etc')).toBe(false);
+        expect(isValidDeviceName('a..b')).toBe(false);
+        expect(isValidDeviceName('..')).toBe(false);
+    });
+
+    it('rejects empty, whitespace-only, and oversized inputs', () => {
+        expect(isValidDeviceName('')).toBe(false);
+        expect(isValidDeviceName('   ')).toBe(false);
+        expect(isValidDeviceName('a'.repeat(65))).toBe(false);
+    });
+
+    it('rejects names with no letter or digit', () => {
+        expect(isValidDeviceName('...')).toBe(false);
+        expect(isValidDeviceName('---')).toBe(false);
+        expect(isValidDeviceName("()'")).toBe(false);
+    });
+
+    it('rejects undefined (matches server typeof guard)', () => {
+        expect(isValidDeviceName(undefined)).toBe(false);
+    });
+
+    it('rejects null (matches server typeof guard)', () => {
+        expect(isValidDeviceName(null)).toBe(false);
+    });
+
+    it('rejects a number (matches server typeof guard)', () => {
+        expect(isValidDeviceName(12345)).toBe(false);
+    });
+
+    it('trims leading and trailing whitespace before validating', () => {
+        expect(isValidDeviceName('  Kitchen  ')).toBe(true);
+    });
+});
+
+describe('normalizeDeviceName', () => {
+    it('collapses NFD and NFC forms of the same accented name', () => {
+        const composed = 'café';           // é as a single precomposed code point (NFC)
+        const decomposed = 'café';  // e + combining acute (NFD)
+        expect(composed).not.toBe(decomposed);
+        expect(normalizeDeviceName(composed)).toBe(normalizeDeviceName(decomposed));
+        expect(normalizeDeviceName(decomposed)).toBe(composed);
+    });
+
+    it('trims whitespace', () => {
+        expect(normalizeDeviceName('  Kitchen Display  ')).toBe('Kitchen Display');
+    });
+
+    it('returns empty string for non-strings', () => {
+        expect(normalizeDeviceName(null)).toBe('');
+        expect(normalizeDeviceName(undefined)).toBe('');
+        expect(normalizeDeviceName(12345)).toBe('');
     });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -118,6 +118,11 @@ const {
   decryptLegacy,
 } = require('./utils/encryption');
 const { httpsAgentFor, isCertificateVerificationSkipped } = require('./utils/outboundTls');
+const {
+  DEVICE_NAME_RULE_MESSAGE,
+  isValidDeviceName,
+  normalizeDeviceName,
+} = require('./utils/deviceName');
 
 // Certificate policy for every outbound axios request, decided per URL from the
 // target's address class (issue #139). Registered on the default axios instance,
@@ -2270,6 +2275,7 @@ function ensureDeviceExists(deviceName) {
   db.prepare('INSERT OR IGNORE INTO devices (name, updateTime) VALUES (?, CURRENT_TIMESTAMP)').run(deviceName);
   ensureHomeTabExists(deviceName);
 }
+
 function touchDeviceUpdateTime(deviceName) {
   db.prepare('UPDATE devices SET updateTime = CURRENT_TIMESTAMP WHERE name = ?').run(deviceName);
 }
@@ -2361,10 +2367,16 @@ fastify.patch('/api/devices/:deviceName', async (request, reply) => {
     return reply.status(400).send({ error: 'name is required' });
   }
 
-  const trimmedNewName = newName.trim();
+  // NFC-normalise so two visually identical accented names collapse to the
+  // same string on write and on the duplicate check below.
+  const normalizedNewName = normalizeDeviceName(newName);
 
-  if (trimmedNewName === deviceName) {
-    return { success: true, name: trimmedNewName, message: 'Device name unchanged' };
+  if (!isValidDeviceName(normalizedNewName)) {
+    return reply.status(400).send({ error: DEVICE_NAME_RULE_MESSAGE });
+  }
+
+  if (normalizedNewName === deviceName) {
+    return { success: true, name: normalizedNewName, message: 'Device name unchanged' };
   }
 
   try {
@@ -2373,13 +2385,13 @@ fastify.patch('/api/devices/:deviceName', async (request, reply) => {
       return reply.status(404).send({ error: 'Device not found' });
     }
 
-    const alreadyUsed = db.prepare('SELECT name FROM devices WHERE name = ?').get(trimmedNewName);
+    const alreadyUsed = db.prepare('SELECT name FROM devices WHERE name = ?').get(normalizedNewName);
     if (alreadyUsed) {
       return reply.status(409).send({ error: 'A device with that name already exists' });
     }
 
-    db.prepare('UPDATE devices SET name = ?, updateTime = CURRENT_TIMESTAMP WHERE name = ?').run(trimmedNewName, deviceName);
-    return { success: true, name: trimmedNewName, message: 'Device name updated successfully' };
+    db.prepare('UPDATE devices SET name = ?, updateTime = CURRENT_TIMESTAMP WHERE name = ?').run(normalizedNewName, deviceName);
+    return { success: true, name: normalizedNewName, message: 'Device name updated successfully' };
   } catch (error) {
     console.error('Error updating device name:', error);
     reply.status(500).send({ error: 'Failed to update device name' });

--- a/server/tests/deviceName.test.js
+++ b/server/tests/deviceName.test.js
@@ -1,0 +1,85 @@
+// Allow-list rule for device names. The bug is that '/' in a
+// name splits the URL path at nginx, so the fix is to constrain the charset
+// when a human picks a name. The rule allows Unicode letters and digits plus
+// a small set of punctuation ( _ - . ' ( ) ) that carries no URL meaning.
+// The client mirrors this rule so the server 400 is a backstop rather than
+// the user's first experience of the constraint.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    isValidDeviceName,
+    normalizeDeviceName,
+    DEVICE_NAME_MAX_LENGTH,
+} = require('../utils/deviceName');
+
+test('isValidDeviceName accepts common human-picked names', () => {
+    assert.equal(isValidDeviceName('Kitchen Display'), true);
+    assert.equal(isValidDeviceName("Nan's iPad"), true);
+    assert.equal(isValidDeviceName('Playroom (up)'), true);
+    assert.equal(isValidDeviceName('José'), true);
+    assert.equal(isValidDeviceName('Kitchen_Hub-2'), true);
+    assert.equal(isValidDeviceName('a'), true);
+    assert.equal(isValidDeviceName('a'.repeat(DEVICE_NAME_MAX_LENGTH)), true);
+});
+
+test('isValidDeviceName rejects URL-meaningful characters', () => {
+    assert.equal(isValidDeviceName('a/b'), false);
+    assert.equal(isValidDeviceName('a\\b'), false);
+    assert.equal(isValidDeviceName('a?b'), false);
+    assert.equal(isValidDeviceName('a#b'), false);
+    assert.equal(isValidDeviceName('a%b'), false);
+    assert.equal(isValidDeviceName('a&b'), false);
+    assert.equal(isValidDeviceName('a+b'), false);
+    assert.equal(isValidDeviceName('a:b'), false);
+    assert.equal(isValidDeviceName('a@b'), false);
+});
+
+test('isValidDeviceName rejects path-traversal-shaped inputs', () => {
+    assert.equal(isValidDeviceName('../etc'), false);
+    assert.equal(isValidDeviceName('a..b'), false);
+    assert.equal(isValidDeviceName('..'), false);
+});
+
+test('isValidDeviceName rejects whitespace-only, empty, and oversized inputs', () => {
+    assert.equal(isValidDeviceName(''), false);
+    assert.equal(isValidDeviceName('   '), false);
+    assert.equal(isValidDeviceName('a'.repeat(DEVICE_NAME_MAX_LENGTH + 1)), false);
+});
+
+test('isValidDeviceName rejects names with no letter or digit', () => {
+    assert.equal(isValidDeviceName('...'), false);
+    assert.equal(isValidDeviceName('---'), false);
+    assert.equal(isValidDeviceName("()'"), false);
+});
+
+test('isValidDeviceName rejects non-string inputs', () => {
+    assert.equal(isValidDeviceName(null), false);
+    assert.equal(isValidDeviceName(undefined), false);
+    assert.equal(isValidDeviceName(123), false);
+});
+
+test('isValidDeviceName trims leading and trailing whitespace before validating', () => {
+    // A caller passing a raw form value with padding is still valid — the
+    // route stores the trimmed form via normalizeDeviceName.
+    assert.equal(isValidDeviceName('  Kitchen  '), true);
+});
+
+test('normalizeDeviceName collapses NFD and NFC forms of the same accented name', () => {
+    const composed = 'café';         // é as a single precomposed code point (NFC)
+    const decomposed = 'café';      // e + combining acute (NFD)
+    assert.notEqual(composed, decomposed);
+    assert.equal(normalizeDeviceName(composed), normalizeDeviceName(decomposed));
+    assert.equal(normalizeDeviceName(decomposed), composed);
+});
+
+test('normalizeDeviceName trims whitespace', () => {
+    assert.equal(normalizeDeviceName('  Kitchen Display  '), 'Kitchen Display');
+});
+
+test('normalizeDeviceName returns empty string for non-strings', () => {
+    assert.equal(normalizeDeviceName(null), '');
+    assert.equal(normalizeDeviceName(undefined), '');
+    assert.equal(normalizeDeviceName(123), '');
+});

--- a/server/utils/deviceName.js
+++ b/server/utils/deviceName.js
@@ -1,0 +1,46 @@
+// Device names live in URL paths (`/api/devices/<name>`) and are echoed back
+// into localStorage on the client. The rule here is an allow-list applied at
+// WRITE time only: rename endpoints and any endpoint that takes a
+// user-supplied new name go through this. Reads must not validate — an
+// existing row's name is a fact about the world, and rejecting a name we
+// already accepted would brick displays that work fine today.
+//
+// The charset is narrower than what our current nginx tolerates. It stays
+// correct if HomeGlow is fronted by Caddy or Apache, or by nginx with
+// different merge_slashes settings. Characters like / \ % ? # & + : @ are
+// deliberately excluded even though a few of them happen to work today.
+//
+// The client mirrors this rule in client/src/utils/deviceName.js so the
+// server 400 is a backstop, not the user's first experience of the
+// constraint.
+
+const DEVICE_NAME_ALLOWED = /^[\p{L}\p{N} _\-.'()]+$/u;
+const DEVICE_NAME_HAS_ALNUM = /[\p{L}\p{N}]/u;
+const DEVICE_NAME_MAX_LENGTH = 64;
+const DEVICE_NAME_RULE_MESSAGE =
+    'Device name must be 1–64 characters, contain at least one letter or digit, must not contain "..", and may only include letters, digits, spaces, and _ - . \' ( ).';
+
+// NFC so two visually identical accented names do not create two devices —
+// e.g. "café" typed as U+00E9 vs "café" (e + combining acute).
+function normalizeDeviceName(raw) {
+    if (typeof raw !== 'string') return '';
+    return raw.normalize('NFC').trim();
+}
+
+function isValidDeviceName(name) {
+    if (typeof name !== 'string') return false;
+    const normalized = normalizeDeviceName(name);
+    if (normalized.length < 1 || normalized.length > DEVICE_NAME_MAX_LENGTH) return false;
+    if (normalized.includes('..')) return false;
+    if (!DEVICE_NAME_ALLOWED.test(normalized)) return false;
+    if (!DEVICE_NAME_HAS_ALNUM.test(normalized)) return false;
+    return true;
+}
+
+module.exports = {
+    DEVICE_NAME_ALLOWED,
+    DEVICE_NAME_MAX_LENGTH,
+    DEVICE_NAME_RULE_MESSAGE,
+    isValidDeviceName,
+    normalizeDeviceName,
+};


### PR DESCRIPTION
A device name containing `/` bricks that device: the dashboard stops rendering, and the device cannot be deleted through the UI either.

## The failure

The client escapes the name correctly — `getDeviceApiBase` uses `encodeURIComponent`, so `/` becomes `%2F`. **nginx decodes it before proxying**, so `/api/devices/<name>/settings` splits into a path that matches no route, and every request for that device 404s. Deleting it goes through the same path shape, so the UI offers no way out.

Reproduced on a stock instance:

```
PUT /api/devices/Kitchen%20Display/settings   -> 200   (a space is fine)
PUT /api/devices/a%2Fb/settings               -> 404   (the bug)
```

## The fix, and one thing it deliberately does not do

**Validation happens on rename only** — the one place a human chooses a name. Reads are untouched, and `ensureDeviceExists` is unchanged.

That restraint is the important part. An earlier revision of this change validated on the lookup path too, which meant an existing device called `Kitchen Display` would start failing *on upgrade* — breaking displays that work today in order to fix ones that are already broken. An existing row's name is a fact about the world; rejecting a name the application previously accepted and stored is not a fix.

For the same reason there is **no migration and no sweep**. Repairing an install that already holds a bad name would require rewriting the name server-side *and* in every browser's `localStorage`, since the client holds its own identity and would keep requesting the old one. That is a permanent cost on every page load of every install, to fix a rare condition. `getDeviceName` still returns exactly what is stored.

## The rule

An allow-list rather than a deny-list, so it stays correct if HomeGlow is fronted by Caddy or Apache, or by nginx with different `merge_slashes` settings:

```js
/^[\p{L}\p{N} _\-.'()]+$/u
```

Unicode letters and digits, space, and the punctuation people actually use for a screen in their house — `Kitchen Display`, `Nan's iPad`, `Playroom (up)`, `José`. Characters carrying URL meaning (`/ \ % ? # & + : @`) are excluded even where the current nginx tolerates them.

Plus: NFC-normalised so an accented name typed two ways cannot produce two devices that look identical; 1–64 characters after trimming; at least one letter or digit; no `..`.

The charset is intentionally broader than the bug strictly requires. Only `/` is known to break today — but `%`, `?` and `#` have URL meaning that a different front end may well act on, and a device name has no need of them.

## Client side

The rename dialog validates as you type, disabling the confirm action with inline helper text, so the server 400 is a backstop rather than the user's first encounter with the rule. Both implementations are checked against each other; an earlier revision diverged because `RegExp.prototype.test()` coerces its argument, so `isValidDeviceName(undefined)` tested the string `"undefined"` and returned `true` on the client while the server returned `false`.

## Testing

`server/tests/deviceName.test.js` and `client/src/utils/deviceName.test.js` cover the valid names above, `/`, `..`, whitespace-only, pure punctuation, over-length, and non-string inputs — plus a case asserting the two NFC spellings of an accented name resolve to the same device.

Full suites on Node 20 (matching `ci-tests.yml`): backend **190 passing**, frontend **120 passing**, `check:i18n` 715/715, client build clean.
