### PR TITLE
Per-device show/hide of users in the Chores widget

### DIFF
--- a/client/src/components/ChoreWidget.jsx
+++ b/client/src/components/ChoreWidget.jsx
@@ -27,9 +27,11 @@ import {
   ListItemButton,
   ListItemAvatar,
   Radio,
-  RadioGroup
+  RadioGroup,
+  Popover,
+  Switch
 } from '@mui/material';
-import { Edit, Save, Cancel, Add, Delete, Check, Undo, SwapHoriz, Snooze, Backspace } from '@mui/icons-material';
+import { Edit, Save, Cancel, Add, Delete, Check, Undo, SwapHoriz, Snooze, Backspace, Settings as SettingsIcon } from '@mui/icons-material';
 import axios from 'axios';
 import { useTranslation } from 'react-i18next';
 import LoadingBackdrop from './LoadingBackdrop';
@@ -37,6 +39,7 @@ import PinModal from './PinModal';
 import { API_BASE_URL } from '../utils/apiConfig.js';
 import { getDeviceApiBase } from '../utils/deviceName.js';
 import { shouldShowChoreToday, getTodayDateString, convertDaysToCrontab, getDueDateStatus, formatDueDate } from '../utils/choreHelpers.js';
+import { filterVisibleUsers, toggleHiddenUserId, pruneHiddenUserIds } from '../utils/choreUserVisibility.js';
 import { subscribePluginEvents } from '../utils/pluginEventBridge.js';
 import { playSound, soundUrl } from '../utils/choreSound.js';
 import { formatTime } from '../utils/dateUtils.js';
@@ -79,6 +82,11 @@ const ChoreWidget = ({ refreshNonce = 0 }) => {
   const [loading, setLoading] = useState(true);
   const [showBonusChores, setShowBonusChores] = useState(true);
   const [soundEnabled, setSoundEnabled] = useState(true);
+  // Per-device: which real users this display hides. Bonus pseudo-user (id 0)
+  // is not a real user and is not offered in the selector — the "Bonus Chores"
+  // column already has its own toggle.
+  const [hiddenUserIds, setHiddenUserIds] = useState([]);
+  const [settingsAnchor, setSettingsAnchor] = useState(null);
   const [deviceSettingsLoaded, setDeviceSettingsLoaded] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [dailyClamReward, setDailyClamReward] = useState(2);
@@ -124,6 +132,12 @@ const ChoreWidget = ({ refreshNonce = 0 }) => {
         if (choreSettings && typeof choreSettings.soundEnabled === 'boolean') {
           setSoundEnabled(choreSettings.soundEnabled);
         }
+        if (choreSettings && Array.isArray(choreSettings.hiddenUserIds)) {
+          // Coerce here so a JSON-round-tripped string id still matches later.
+          setHiddenUserIds(choreSettings.hiddenUserIds
+            .map((id) => Number(id))
+            .filter((id) => Number.isFinite(id)));
+        }
       } catch (error) {
         console.error('Error loading chore widget settings:', error);
       } finally {
@@ -154,6 +168,7 @@ const ChoreWidget = ({ refreshNonce = 0 }) => {
           choreWidgetSettings: {
             showBonusChores,
             soundEnabled,
+            hiddenUserIds,
           },
         });
       } catch (error) {
@@ -162,7 +177,7 @@ const ChoreWidget = ({ refreshNonce = 0 }) => {
     }, 250);
 
     return () => clearTimeout(timeoutId);
-  }, [API_DEVICE_URL, deviceSettingsLoaded, showBonusChores, soundEnabled]);
+  }, [API_DEVICE_URL, deviceSettingsLoaded, showBonusChores, soundEnabled, hiddenUserIds]);
 
   useEffect(() => {
     const onUsersUpdated = () => {
@@ -1048,6 +1063,9 @@ const ChoreWidget = ({ refreshNonce = 0 }) => {
   }
 
   const availableBonusChores = getAvailableBonusChores();
+  // Users the widget will render as columns on this device. Ordering carries
+  // through from the server (admin sort_order); the filter only removes.
+  const visibleUsers = filterVisibleUsers(users, hiddenUserIds);
 
   return (
     <>
@@ -1087,6 +1105,15 @@ const ChoreWidget = ({ refreshNonce = 0 }) => {
             >
               🛍️
             </Button>
+            <IconButton
+              onClick={(event) => setSettingsAnchor(event.currentTarget)}
+              size="small"
+              aria-label={t('chores:visibility.openSettings')}
+              title={t('chores:visibility.openSettings')}
+              sx={{ color: 'var(--text-color)' }}
+            >
+              <SettingsIcon fontSize="small" />
+            </IconButton>
             <Button
               startIcon={<Add />}
               onClick={() => setShowAddDialog(true)}
@@ -1107,7 +1134,26 @@ const ChoreWidget = ({ refreshNonce = 0 }) => {
             alignItems: 'flex-start',
             width: '100%'
           }}>
-            {users.filter(user => user.id !== 0).map(user => {
+            {visibleUsers.length === 0 && !showBonusChores && (
+              // Wall display fallback — a blank widget looks like a crash. Tell
+              // the user where to bring someone back.
+              <Box sx={{
+                flex: '1 1 0',
+                minWidth: '180px',
+                border: '2px dashed var(--card-border)',
+                borderRadius: 2,
+                p: 3,
+                textAlign: 'center'
+              }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
+                  {t('chores:visibility.allHiddenTitle')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {t('chores:visibility.allHiddenBody')}
+                </Typography>
+              </Box>
+            )}
+            {visibleUsers.map(user => {
               const userChores = getUserChoresForToday(user.id);
               const completedChores = userChores.filter(c => c.completed && c.clam_value === 0).length;
               const totalRegularChores = userChores.filter(c => c.clam_value === 0).length;
@@ -1749,6 +1795,50 @@ const ChoreWidget = ({ refreshNonce = 0 }) => {
             <Button variant="contained" onClick={confirmSnooze}>{t('chores:snooze.confirm')}</Button>
           </DialogActions>
         </Dialog>
+
+        {/* Per-device settings: which users this display shows */}
+        <Popover
+          open={Boolean(settingsAnchor)}
+          anchorEl={settingsAnchor}
+          onClose={() => setSettingsAnchor(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        >
+          <Box sx={{ p: 2, minWidth: 260, maxHeight: '80vh', overflowY: 'auto' }}>
+            <Typography variant="h6" sx={{ mb: 1 }}>
+              {t('chores:visibility.heading')}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+              {t('chores:visibility.helper')}
+            </Typography>
+            {users.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                {t('chores:visibility.noUsers')}
+              </Typography>
+            ) : (
+              <FormGroup>
+                {users.map((user) => {
+                  const hidden = hiddenUserIds.map(Number).includes(Number(user.id));
+                  return (
+                    <FormControlLabel
+                      key={user.id}
+                      control={
+                        <Switch
+                          size="small"
+                          checked={!hidden}
+                          onChange={() => setHiddenUserIds((prev) =>
+                            pruneHiddenUserIds(toggleHiddenUserId(prev, user.id), users)
+                          )}
+                        />
+                      }
+                      label={user.username}
+                    />
+                  );
+                })}
+              </FormGroup>
+            )}
+          </Box>
+        </Popover>
 
         {/* Admin PIN confirmation for transfer/snooze */}
         <PinModal

--- a/client/src/i18n/locales/en/chores.json
+++ b/client/src/i18n/locales/en/chores.json
@@ -153,6 +153,14 @@
   "celebration": {
     "redeemedAPrize": "{{name}} redeemed a prize!"
   },
+  "visibility": {
+    "openSettings": "Chore widget settings",
+    "heading": "Show on this display",
+    "helper": "Choose which people appear as columns on this display. Others keep seeing everyone.",
+    "noUsers": "No people to show yet.",
+    "allHiddenTitle": "Nobody is showing on this display",
+    "allHiddenBody": "Open the chore widget settings (gear icon) and turn someone back on."
+  },
   "schedules": {
     "definitionsHeading": "Chore Definitions",
     "newChore": "New Chore",

--- a/client/src/i18n/locales/es/chores.json
+++ b/client/src/i18n/locales/es/chores.json
@@ -153,6 +153,14 @@
   "celebration": {
     "redeemedAPrize": "¡{{name}} canjeó un premio!"
   },
+  "visibility": {
+    "openSettings": "Ajustes del widget de tareas",
+    "heading": "Mostrar en esta pantalla",
+    "helper": "Elige quién aparece como columna en esta pantalla. Las demás pantallas seguirán viendo a todos.",
+    "noUsers": "Aún no hay personas para mostrar.",
+    "allHiddenTitle": "No se muestra a nadie en esta pantalla",
+    "allHiddenBody": "Abre los ajustes del widget de tareas (icono del engranaje) y vuelve a activar a alguien."
+  },
   "schedules": {
     "definitionsHeading": "Definiciones de tareas",
     "newChore": "Nueva tarea",

--- a/client/src/utils/choreUserVisibility.js
+++ b/client/src/utils/choreUserVisibility.js
@@ -1,0 +1,57 @@
+// Per-device visibility for the Chores widget columns.
+//
+// Ordering is global (users.sort_order, admin-controlled). Visibility is
+// per-device: each display stores the *hidden* user ids in its
+// choreWidgetSettings blob. Storing what is hidden (not what is shown) means a
+// user added later appears everywhere by default instead of being invisible
+// until someone opts them in on every display.
+
+// Filter a user list by a hidden-id list, preserving input order.
+//
+// Coerces stored ids to numbers so a JSON round-trip that turned them into
+// strings still matches, and drops any id that no longer resolves to a live
+// user (defensive against a user deleted while still in a device's hidden
+// list — the display should just show the survivors, never crash).
+export const filterVisibleUsers = (users, hiddenUserIds) => {
+  if (!Array.isArray(users)) return [];
+  if (!Array.isArray(hiddenUserIds) || hiddenUserIds.length === 0) {
+    return users.slice();
+  }
+  const hidden = new Set(hiddenUserIds.map((id) => Number(id)));
+  return users.filter((user) => !hidden.has(Number(user?.id)));
+};
+
+// Toggle a user id in the hidden list. Returns a new array — never mutates
+// the input, and normalizes stored ids to numbers so equality is consistent
+// with filterVisibleUsers.
+export const toggleHiddenUserId = (hiddenUserIds, userId) => {
+  const id = Number(userId);
+  const current = Array.isArray(hiddenUserIds)
+    ? hiddenUserIds.map((entry) => Number(entry))
+    : [];
+  if (current.includes(id)) {
+    return current.filter((entry) => entry !== id);
+  }
+  return [...current, id];
+};
+
+// Sanitize a stored hidden list against the live user set: drop non-numeric
+// entries, drop ids that no longer resolve, and dedupe. Used before persisting
+// so stale ids do not accumulate over time.
+export const pruneHiddenUserIds = (hiddenUserIds, users) => {
+  if (!Array.isArray(hiddenUserIds)) return [];
+  const liveIds = new Set(
+    (Array.isArray(users) ? users : []).map((user) => Number(user?.id))
+  );
+  const seen = new Set();
+  const pruned = [];
+  for (const entry of hiddenUserIds) {
+    const id = Number(entry);
+    if (!Number.isFinite(id)) continue;
+    if (!liveIds.has(id)) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    pruned.push(id);
+  }
+  return pruned;
+};

--- a/client/src/utils/choreUserVisibility.test.js
+++ b/client/src/utils/choreUserVisibility.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterVisibleUsers,
+  toggleHiddenUserId,
+  pruneHiddenUserIds,
+} from './choreUserVisibility.js';
+
+const USERS = [
+  { id: 1, username: 'Ada', sort_order: 0 },
+  { id: 2, username: 'Bee', sort_order: 1 },
+  { id: 3, username: 'Cy', sort_order: 2 },
+];
+
+describe('filterVisibleUsers', () => {
+  it('returns everyone when the hidden list is absent', () => {
+    expect(filterVisibleUsers(USERS, undefined)).toEqual(USERS);
+    expect(filterVisibleUsers(USERS, null)).toEqual(USERS);
+  });
+
+  it('returns everyone when the hidden list is empty', () => {
+    expect(filterVisibleUsers(USERS, [])).toEqual(USERS);
+  });
+
+  it('hides a single user by id', () => {
+    expect(filterVisibleUsers(USERS, [2]).map((u) => u.id)).toEqual([1, 3]);
+  });
+
+  it('hides all users when every id is on the list', () => {
+    expect(filterVisibleUsers(USERS, [1, 2, 3])).toEqual([]);
+  });
+
+  it('preserves input order (which carries the admin sort_order)', () => {
+    const reversed = [...USERS].reverse();
+    expect(filterVisibleUsers(reversed, [2]).map((u) => u.id)).toEqual([3, 1]);
+  });
+
+  it('ignores stale ids that no longer match a live user', () => {
+    // 99 has been deleted from the system but still lingers in a device's
+    // stored hidden list — the widget must still render the survivors.
+    expect(filterVisibleUsers(USERS, [99, 2]).map((u) => u.id)).toEqual([1, 3]);
+  });
+
+  it('tolerates ids that arrive as strings after a JSON round-trip', () => {
+    expect(filterVisibleUsers(USERS, ['2']).map((u) => u.id)).toEqual([1, 3]);
+  });
+
+  it('returns [] for a non-array user list', () => {
+    expect(filterVisibleUsers(null, [1])).toEqual([]);
+    expect(filterVisibleUsers(undefined, [1])).toEqual([]);
+  });
+});
+
+describe('toggleHiddenUserId', () => {
+  it('adds a user id that is not on the list', () => {
+    expect(toggleHiddenUserId([], 2)).toEqual([2]);
+    expect(toggleHiddenUserId([1], 2)).toEqual([1, 2]);
+  });
+
+  it('removes a user id that is already on the list', () => {
+    expect(toggleHiddenUserId([1, 2, 3], 2)).toEqual([1, 3]);
+  });
+
+  it('does not mutate the input', () => {
+    const input = [1, 2];
+    toggleHiddenUserId(input, 3);
+    expect(input).toEqual([1, 2]);
+  });
+
+  it('starts from empty when the input is not an array', () => {
+    expect(toggleHiddenUserId(null, 2)).toEqual([2]);
+    expect(toggleHiddenUserId(undefined, 2)).toEqual([2]);
+  });
+
+  it('normalizes string ids so toggling stays idempotent', () => {
+    expect(toggleHiddenUserId(['2'], 2)).toEqual([]);
+  });
+});
+
+describe('pruneHiddenUserIds', () => {
+  it('drops ids that no longer resolve to a live user', () => {
+    expect(pruneHiddenUserIds([1, 99, 2], USERS)).toEqual([1, 2]);
+  });
+
+  it('dedupes and coerces to numbers', () => {
+    expect(pruneHiddenUserIds([1, '1', 2, 2], USERS)).toEqual([1, 2]);
+  });
+
+  it('returns [] for non-array input', () => {
+    expect(pruneHiddenUserIds(null, USERS)).toEqual([]);
+  });
+});

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -114,6 +114,12 @@ optional follow-up **reminder interval** that repeats until the chore is complet
   1. **Global master** (`CHORE_SOUND_ENABLED`) in Admin → Chores + a default sound and volume.
   2. **Per-device mute** — the 🔔/🔕 button on the chore widget (stored in
      `choreWidgetSettings.soundEnabled` in device settings) silences one display.
+
+- **Per-device user visibility** (`choreWidgetSettings.hiddenUserIds`): the gear on
+  the chore widget hides users on that display only. Ordering stays global
+  (`users.sort_order`). Stores who is *hidden*, so a user added later shows up
+  everywhere by default. Hiding everyone shows an explanatory panel rather than an
+  empty widget.
   3. **Per-schedule** `sound_enabled` + `due_time`.
 - **The ringer** runs app-level (`useChoreSoundScheduler`), so it fires regardless of
   which tab is showing. It rings once at the due time if the chore is still incomplete


### PR DESCRIPTION
A display in one room often only needs some of the users. The gear on the chore widget now hides users on that display alone.

**Ordering stays global** — `users.sort_order` is admin-controlled and untouched. Only visibility is per device, stored as hidden ids in `choreWidgetSettings.hiddenUserIds`, so there's **no migration**.

It stores who is *hidden* rather than who is shown, deliberately: storing the visible set would make a user added later invisible on every existing display until someone opted them in on each one.

Hiding everyone renders an explanatory panel rather than an empty widget — on a wall display a blank widget reads as a crash. Stale ids are pruned against the live user list, so a deleted user can't break a display.

Filtering and toggling logic is in `utils/choreUserVisibility.js` with tests. `features.md` updated.

Tested on a real instance, both themes and narrow widths. Node 20: client 144, server 190, `check:i18n` 715/715, build clean.
