### PR TITLE
Read iCloud subscribed calendars from their source feed

### DIFF
--- a/server/services/appleCalDAV.js
+++ b/server/services/appleCalDAV.js
@@ -17,6 +17,81 @@ const xmlParser = new XMLParser({
   trimValues: true,
 });
 
+// ---------------------------------------------------------------------------
+// Outbound CalDAV request bodies
+//
+// Every request body lives here so the wire format is in one place instead of
+// being scattered through the request functions. JavaScript has no `static final`,
+// so this is a frozen class with static fields — the closest equivalent: the
+// values cannot be reassigned, and strings are immutable already.
+//
+// CALENDAR_QUERY is the one exception to "static string": a calendar-query REPORT
+// must carry a concrete time-range, so it is a builder.
+// ---------------------------------------------------------------------------
+class ICLOUD_XML_MESSAGE {
+  // PROPFIND Depth:0 against the service root -> current-user-principal href.
+  static CURRENT_USER_PRINCIPAL = `<?xml version="1.0" encoding="utf-8"?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop>
+    <d:current-user-principal />
+  </d:prop>
+</d:propfind>`;
+
+  // PROPFIND Depth:0 against the principal -> calendar-home-set href.
+  static CALENDAR_HOME_SET = `<?xml version="1.0" encoding="utf-8"?>
+<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:prop>
+    <c:calendar-home-set />
+  </d:prop>
+</d:propfind>`;
+
+  // PROPFIND Depth:1 against the calendar home -> one entry per collection.
+  // cs:source is required: it is the only way a subscription's upstream feed URL
+  // becomes discoverable. Without it, subscriptions look like empty calendars.
+  static CALENDAR_LIST = `<?xml version="1.0" encoding="utf-8"?>
+<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
+  <d:prop>
+    <d:displayname />
+    <d:resourcetype />
+    <ical:calendar-color />
+    <cs:getctag />
+    <cs:source />
+    <c:supported-calendar-component-set />
+  </d:prop>
+</d:propfind>`;
+
+  // PROPFIND Depth:0 against a single collection -> is it a subscription, and
+  // where does its feed live? Kept minimal so the probe stays cheap.
+  static COLLECTION_SOURCE = `<?xml version="1.0" encoding="utf-8"?>
+<d:propfind xmlns:d="DAV:" xmlns:cs="http://calendarserver.org/ns/">
+  <d:prop>
+    <d:resourcetype />
+    <cs:source />
+  </d:prop>
+</d:propfind>`;
+
+  // REPORT against a calendar collection -> etag + ICS payload per event that
+  // overlaps the window. Both bounds are UTC basic-format (YYYYMMDDTHHMMSSZ).
+  static CALENDAR_QUERY(startUtc, endUtc) {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:prop>
+    <d:getetag />
+    <c:calendar-data />
+  </d:prop>
+  <c:filter>
+    <c:comp-filter name="VCALENDAR">
+      <c:comp-filter name="VEVENT">
+        <c:time-range start="${startUtc}" end="${endUtc}" />
+      </c:comp-filter>
+    </c:comp-filter>
+  </c:filter>
+</c:calendar-query>`;
+  }
+}
+
+Object.freeze(ICLOUD_XML_MESSAGE);
+
 function buildAuthHeader(appleId, appPassword) {
   return 'Basic ' + Buffer.from(`${appleId}:${appPassword}`).toString('base64');
 }
@@ -218,12 +293,7 @@ async function discoverPrincipalUrl(appleId, appPassword) {
       'Depth': '0',
       'Content-Type': 'application/xml; charset=utf-8',
     },
-    data: `<?xml version="1.0" encoding="utf-8"?>
-<d:propfind xmlns:d="DAV:">
-  <d:prop>
-    <d:current-user-principal />
-  </d:prop>
-</d:propfind>`,
+    data: ICLOUD_XML_MESSAGE.CURRENT_USER_PRINCIPAL,
     timeout: 15000,
     validateStatus: (s) => s < 500,
   });
@@ -248,12 +318,7 @@ async function discoverCalendarHome(principalUrl, appleId, appPassword) {
       'Depth': '0',
       'Content-Type': 'application/xml; charset=utf-8',
     },
-    data: `<?xml version="1.0" encoding="utf-8"?>
-<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
-  <d:prop>
-    <c:calendar-home-set />
-  </d:prop>
-</d:propfind>`,
+    data: ICLOUD_XML_MESSAGE.CALENDAR_HOME_SET,
     timeout: 15000,
     validateStatus: (s) => s < 500,
   });
@@ -285,17 +350,7 @@ async function listCalendars(calendarHomeUrl, appleId, appPassword) {
       'Depth': '1',
       'Content-Type': 'application/xml; charset=utf-8',
     },
-    data: `<?xml version="1.0" encoding="utf-8"?>
-<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
-  <d:prop>
-    <d:displayname />
-    <d:resourcetype />
-    <ical:calendar-color />
-    <cs:getctag />
-    <cs:source />
-    <c:supported-calendar-component-set />
-  </d:prop>
-</d:propfind>`,
+    data: ICLOUD_XML_MESSAGE.CALENDAR_LIST,
     timeout: 15000,
     validateStatus: (s) => s < 500,
   });
@@ -355,13 +410,7 @@ async function describeCollection(calendarUrl, appleId, appPassword) {
       'Depth': '0',
       'Content-Type': 'application/xml; charset=utf-8',
     },
-    data: `<?xml version="1.0" encoding="utf-8"?>
-<d:propfind xmlns:d="DAV:" xmlns:cs="http://calendarserver.org/ns/">
-  <d:prop>
-    <d:resourcetype />
-    <cs:source />
-  </d:prop>
-</d:propfind>`,
+    data: ICLOUD_XML_MESSAGE.COLLECTION_SOURCE,
     timeout: 15000,
     validateStatus: (s) => s < 500,
   });
@@ -431,20 +480,7 @@ async function fetchCalendarEvents(calendarUrl, appleId, appPassword) {
       'Depth': '1',
       'Content-Type': 'application/xml; charset=utf-8',
     },
-    data: `<?xml version="1.0" encoding="utf-8"?>
-<c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
-  <d:prop>
-    <d:getetag />
-    <c:calendar-data />
-  </d:prop>
-  <c:filter>
-    <c:comp-filter name="VCALENDAR">
-      <c:comp-filter name="VEVENT">
-        <c:time-range start="${formatDate(timeMin)}" end="${formatDate(timeMax)}" />
-      </c:comp-filter>
-    </c:comp-filter>
-  </c:filter>
-</c:calendar-query>`,
+    data: ICLOUD_XML_MESSAGE.CALENDAR_QUERY(formatDate(timeMin), formatDate(timeMax)),
     timeout: 30000,
     validateStatus: (s) => s < 500,
   });
@@ -476,6 +512,7 @@ module.exports = {
   discoverAndListCalendars,
   fetchCalendarEvents,
   // Exported for unit testing (pure XML/ICS helpers, no network).
+  ICLOUD_XML_MESSAGE,
   parsePrincipalUrl,
   parseCalendarHomeUrl,
   parseCalendars,

--- a/server/services/appleCalDAV.js
+++ b/server/services/appleCalDAV.js
@@ -59,6 +59,31 @@ function absolutizeUrl(href) {
   return value.startsWith('http') ? value : `${CALDAV_BASE}${value}`;
 }
 
+// iCloud records a subscription's upstream feed as webcal:// (occasionally
+// webcals://). Those are ordinary http(s) URLs wearing a different scheme, which
+// axios will not fetch, so rewrite them. Anything that is still not http(s)
+// afterwards is rejected, so a hostile or malformed <cs:source> cannot talk us
+// into fetching file:// or similar.
+function normalizeFeedUrl(url) {
+  const value = (url || '').trim();
+  if (!value) return null;
+  const rewritten = value.replace(/^webcals?:\/\//i, 'https://');
+  return /^https?:\/\//i.test(rewritten) ? rewritten : null;
+}
+
+// Pull the <cs:source><d:href> feed URL out of a <response>, normalized.
+function extractSourceHref(response) {
+  const sourceProp = findProp(response, 'source');
+  if (!sourceProp) return null;
+  const href = asArray(sourceProp.href)[0];
+  return normalizeFeedUrl(nodeText(href) ?? nodeText(sourceProp));
+}
+
+// True when a parsed resourcetype carries <cs:subscribed/>.
+function isSubscribedResourceType(resourcetype) {
+  return !!resourcetype && typeof resourcetype === 'object' && 'subscribed' in resourcetype;
+}
+
 function parseMultistatusResponses(xmlBody) {
   const doc = xmlParser.parse(xmlBody);
   return asArray(doc && doc.multistatus && doc.multistatus.response);
@@ -132,10 +157,29 @@ function parseCalendars(xmlBody) {
     }
 
     const calUrl = absolutizeUrl(href);
-    calendars.push({ id: calUrl, name, color: color || '#3d7ab5', url: calUrl });
+    calendars.push({
+      id: calUrl,
+      name,
+      color: color || '#3d7ab5',
+      url: calUrl,
+      // Subscriptions hold no event resources of their own; sourceUrl is where
+      // their events actually live. See fetchCalendarEvents.
+      subscribed: isSubscribedResourceType(resourcetype),
+      sourceUrl: extractSourceHref(response),
+    });
   }
 
   return calendars;
+}
+
+// Read subscription details out of a Depth:0 PROPFIND body for one collection.
+function parseCollectionSource(xmlBody) {
+  for (const response of parseMultistatusResponses(xmlBody)) {
+    const subscribed = isSubscribedResourceType(findProp(response, 'resourcetype'));
+    const sourceUrl = extractSourceHref(response);
+    if (subscribed || sourceUrl) return { subscribed, sourceUrl };
+  }
+  return { subscribed: false, sourceUrl: null };
 }
 
 // Extract the raw ICS payload strings from a calendar REPORT response body.
@@ -248,6 +292,7 @@ async function listCalendars(calendarHomeUrl, appleId, appPassword) {
     <d:resourcetype />
     <ical:calendar-color />
     <cs:getctag />
+    <cs:source />
     <c:supported-calendar-component-set />
   </d:prop>
 </d:propfind>`,
@@ -299,8 +344,77 @@ function icsToEvents(icsContent) {
   return events;
 }
 
+// Ask iCloud whether a collection is a subscription, and if so where its events
+// really live. Depth:0 so it stays a cheap single-resource lookup.
+async function describeCollection(calendarUrl, appleId, appPassword) {
+  const response = await axios({
+    method: 'PROPFIND',
+    url: calendarUrl,
+    headers: {
+      'Authorization': buildAuthHeader(appleId, appPassword),
+      'Depth': '0',
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+    data: `<?xml version="1.0" encoding="utf-8"?>
+<d:propfind xmlns:d="DAV:" xmlns:cs="http://calendarserver.org/ns/">
+  <d:prop>
+    <d:resourcetype />
+    <cs:source />
+  </d:prop>
+</d:propfind>`,
+    timeout: 15000,
+    validateStatus: (s) => s < 500,
+  });
+
+  if (response.status !== 207 && response.status !== 200) {
+    return { subscribed: false, sourceUrl: null };
+  }
+
+  return parseCollectionSource(response.data);
+}
+
+// Fetch a subscribed calendar's events straight from its upstream ICS feed.
+// Deliberately unauthenticated: the feed is hosted by a third party (TeamSnap,
+// leagues, school districts), so the iCloud app password must never be sent there.
+async function fetchSubscriptionEvents(feedUrl) {
+  const response = await axios.get(feedUrl, {
+    timeout: 30000,
+    responseType: 'text',
+    // Keep the body a raw string; ICAL.parse needs the original text.
+    transformResponse: [(data) => data],
+    maxRedirects: 5,
+    validateStatus: (s) => s < 500,
+  });
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to fetch subscribed calendar feed (HTTP ${response.status}).`);
+  }
+
+  return icsToEvents(response.data);
+}
+
 // Fetch events from a specific calendar URL using CalDAV REPORT
 async function fetchCalendarEvents(calendarUrl, appleId, appPassword) {
+  // An iCloud subscription (a webcal feed added to iCloud) is a pointer, not a
+  // container: its resourcetype is <cs:subscribed/> and the events live at the
+  // <cs:source> URL. A calendar-query REPORT against one succeeds but returns an
+  // empty multistatus, which surfaced as "synced 0 events" with no error. Detect
+  // that case and read the upstream feed instead.
+  let subscription = { subscribed: false, sourceUrl: null };
+  try {
+    subscription = await describeCollection(calendarUrl, appleId, appPassword);
+  } catch (err) {
+    // Never let the probe break a calendar that the REPORT path already handled.
+    console.warn('Subscription probe failed; falling back to CalDAV REPORT:', err.message);
+  }
+
+  if (subscription.subscribed) {
+    if (!subscription.sourceUrl) {
+      throw new Error('Subscribed iCloud calendar exposes no usable source feed URL.');
+    }
+    return fetchSubscriptionEvents(subscription.sourceUrl);
+  }
+
   const authHeader = buildAuthHeader(appleId, appPassword);
 
   const now = Date.now();
@@ -365,6 +479,8 @@ module.exports = {
   parsePrincipalUrl,
   parseCalendarHomeUrl,
   parseCalendars,
+  parseCollectionSource,
+  normalizeFeedUrl,
   extractIcsPayloads,
   icsToEvents,
 };

--- a/server/tests/appleCalDAV.test.js
+++ b/server/tests/appleCalDAV.test.js
@@ -4,6 +4,8 @@ const {
     parsePrincipalUrl,
     parseCalendarHomeUrl,
     parseCalendars,
+    parseCollectionSource,
+    normalizeFeedUrl,
     extractIcsPayloads,
     icsToEvents,
 } = require('../services/appleCalDAV');
@@ -210,4 +212,95 @@ test('parseCalendars includes shared/subscribed calendars that advertise VEVENT'
     const names = calendars.map((c) => c.name).sort();
     // Work + subscribed Holidays (VEVENT) + Legacy (no comp set, calendar resourcetype)
     assert.deepEqual(names, ['Legacy', 'US Holidays', 'Work']);
+});
+
+test('normalizeFeedUrl rewrites webcal schemes and rejects non-http(s)', () => {
+    assert.equal(
+        normalizeFeedUrl('webcal://example.com/feed.ics'),
+        'https://example.com/feed.ics'
+    );
+    assert.equal(
+        normalizeFeedUrl('WEBCALS://example.com/feed.ics'),
+        'https://example.com/feed.ics'
+    );
+    // Already-usable schemes pass through untouched.
+    assert.equal(
+        normalizeFeedUrl('https://example.com/feed.ics?token=abc'),
+        'https://example.com/feed.ics?token=abc'
+    );
+    assert.equal(normalizeFeedUrl('  http://example.com/f.ics  '), 'http://example.com/f.ics');
+    // Anything else must be refused so <cs:source> cannot redirect us off-protocol.
+    assert.equal(normalizeFeedUrl('file:///etc/passwd'), null);
+    assert.equal(normalizeFeedUrl('ftp://example.com/feed.ics'), null);
+    assert.equal(normalizeFeedUrl(''), null);
+    assert.equal(normalizeFeedUrl(null), null);
+});
+
+test('parseCollectionSource reads the subscription feed URL from a Depth:0 PROPFIND', () => {
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:cs="http://calendarserver.org/ns/">
+  <response>
+    <href>/123456/calendars/subscribed-feed/</href>
+    <propstat><prop>
+      <resourcetype><collection/><cs:subscribed/></resourcetype>
+      <cs:source><href>webcal://example.com/team/schedule.ics</href></cs:source>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+</multistatus>`;
+
+    const result = parseCollectionSource(body);
+    assert.equal(result.subscribed, true);
+    assert.equal(result.sourceUrl, 'https://example.com/team/schedule.ics');
+});
+
+test('parseCollectionSource reports a regular calendar as not subscribed', () => {
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav"
+             xmlns:cs="http://calendarserver.org/ns/">
+  <response>
+    <href>/123456/calendars/home/</href>
+    <propstat><prop>
+      <resourcetype><collection/><caldav:calendar/></resourcetype>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+</multistatus>`;
+
+    const result = parseCollectionSource(body);
+    assert.equal(result.subscribed, false);
+    assert.equal(result.sourceUrl, null);
+});
+
+test('parseCalendars exposes subscribed flag and source feed URL', () => {
+    // Regression: subscriptions were listed in the picker but then queried with a
+    // calendar-query REPORT, which returns an empty multistatus (0 events).
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav"
+             xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
+  <response>
+    <href>/123456/calendars/home/</href>
+    <propstat><prop>
+      <displayname>Family</displayname>
+      <resourcetype><collection/><caldav:calendar/></resourcetype>
+      <caldav:supported-calendar-component-set><caldav:comp name="VEVENT"/></caldav:supported-calendar-component-set>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+  <response>
+    <href>/123456/calendars/sports/</href>
+    <propstat><prop>
+      <displayname>Team Schedule</displayname>
+      <resourcetype><collection/><cs:subscribed/></resourcetype>
+      <cs:source><href>webcal://example.com/team/schedule.ics</href></cs:source>
+      <caldav:supported-calendar-component-set><caldav:comp name="VEVENT"/></caldav:supported-calendar-component-set>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+</multistatus>`;
+
+    const calendars = parseCalendars(body);
+    const byName = Object.fromEntries(calendars.map((c) => [c.name, c]));
+
+    assert.equal(calendars.length, 2);
+    assert.equal(byName['Family'].subscribed, false);
+    assert.equal(byName['Family'].sourceUrl, null);
+    assert.equal(byName['Team Schedule'].subscribed, true);
+    assert.equal(byName['Team Schedule'].sourceUrl, 'https://example.com/team/schedule.ics');
 });

--- a/server/tests/appleCalDAV.test.js
+++ b/server/tests/appleCalDAV.test.js
@@ -1,6 +1,9 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const http = require('node:http');
+const { XMLValidator } = require('fast-xml-parser');
 const {
+    ICLOUD_XML_MESSAGE,
     parsePrincipalUrl,
     parseCalendarHomeUrl,
     parseCalendars,
@@ -8,6 +11,7 @@ const {
     normalizeFeedUrl,
     extractIcsPayloads,
     icsToEvents,
+    fetchCalendarEvents,
 } = require('../services/appleCalDAV');
 
 // Anonymized fixtures: no real names, emails, or principal/DSID values.
@@ -303,4 +307,323 @@ test('parseCalendars exposes subscribed flag and source feed URL', () => {
     assert.equal(byName['Family'].sourceUrl, null);
     assert.equal(byName['Team Schedule'].subscribed, true);
     assert.equal(byName['Team Schedule'].sourceUrl, 'https://example.com/team/schedule.ics');
+});
+
+// ---------------------------------------------------------------------------
+// fetchCalendarEvents behaviour (regression: subscribed calendars synced 0 events)
+//
+// These use a throwaway local http server rather than module mocks, matching the
+// approach in homeAssistant.test.js / outboundTls.test.js. fetchCalendarEvents
+// takes the collection URL as an argument, so pointing it at 127.0.0.1 is enough
+// to observe exactly which requests it makes.
+// ---------------------------------------------------------------------------
+
+function buildVCalendar(summary, uid) {
+    return [
+        'BEGIN:VCALENDAR',
+        'CALSCALE:GREGORIAN',
+        'PRODID:-//Example Inc.//Example//EN',
+        'VERSION:2.0',
+        'BEGIN:VEVENT',
+        'DTSTART;TZID=America/Chicago:20260309T094500',
+        'DTEND;TZID=America/Chicago:20260309T104500',
+        `SUMMARY:${summary}`,
+        `UID:${uid}`,
+        'DTSTAMP:20260108T022826Z',
+        'END:VEVENT',
+        'END:VCALENDAR',
+    ].join('\r\n');
+}
+
+// Stands in for both iCloud (PROPFIND/REPORT) and the third-party feed host (GET),
+// recording every request so a test can assert which path was taken.
+async function startFakeCalDav() {
+    const state = {
+        propfindStatus: 207,
+        propfindBody: '',
+        reportBody: '',
+        feedBody: '',
+        requests: [],
+    };
+
+    const server = http.createServer((req, res) => {
+        let body = '';
+        req.on('data', (chunk) => { body += chunk; });
+        req.on('end', () => {
+            state.requests.push({
+                method: req.method,
+                url: req.url,
+                authorization: req.headers.authorization ?? null,
+                body,
+            });
+
+            if (req.method === 'PROPFIND') {
+                res.statusCode = state.propfindStatus;
+                res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+                res.end(state.propfindStatus >= 500 ? 'upstream exploded' : state.propfindBody);
+                return;
+            }
+            if (req.method === 'REPORT') {
+                res.statusCode = 207;
+                res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+                res.end(state.reportBody);
+                return;
+            }
+            if (req.method === 'GET') {
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'text/calendar; charset=utf-8');
+                res.end(state.feedBody);
+                return;
+            }
+            res.statusCode = 405;
+            res.end();
+        });
+    });
+
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+    return {
+        base: `http://127.0.0.1:${server.address().port}`,
+        state,
+        close: () => new Promise((resolve) => server.close(resolve)),
+    };
+}
+
+function subscribedPropfind(sourceUrl) {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:cs="http://calendarserver.org/ns/">
+  <response>
+    <href>/123456/calendars/sports/</href>
+    <propstat><prop>
+      <resourcetype><collection/><cs:subscribed/></resourcetype>
+      ${sourceUrl ? `<cs:source><href>${sourceUrl}</href></cs:source>` : ''}
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+</multistatus>`;
+}
+
+const REGULAR_PROPFIND = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav">
+  <response>
+    <href>/123456/calendars/home/</href>
+    <propstat><prop>
+      <resourcetype><collection/><caldav:calendar/></resourcetype>
+    </prop><status>HTTP/1.1 200 OK</status></propstat>
+  </response>
+</multistatus>`;
+
+test('fetchCalendarEvents reads a subscribed calendar from its source feed, not via REPORT', async () => {
+    const fake = await startFakeCalDav();
+    try {
+        fake.state.propfindBody = subscribedPropfind(`${fake.base}/team/schedule.ics`);
+        fake.state.feedBody = buildVCalendar('Feed Event', 'feed-uid-1');
+        // If the old code path ran, this REPORT body would be used instead.
+        fake.state.reportBody = `<?xml version="1.0" encoding="UTF-8"?>
+<multistatus xmlns="DAV:"></multistatus>`;
+
+        const events = await fetchCalendarEvents(
+            `${fake.base}/123456/calendars/sports/`,
+            'user@example.com',
+            'app-specific-password'
+        );
+
+        // The regression: this used to be 0 because a calendar-query REPORT against
+        // a subscription returns an empty multistatus.
+        assert.equal(events.length, 1);
+        assert.equal(events[0].title, 'Feed Event');
+
+        const methods = fake.state.requests.map((r) => r.method);
+        assert.ok(methods.includes('PROPFIND'), 'must probe the collection first');
+        assert.ok(methods.includes('GET'), 'must fetch the upstream feed');
+        assert.ok(!methods.includes('REPORT'), 'must not issue a calendar-query REPORT');
+    } finally {
+        await fake.close();
+    }
+});
+
+test('fetchCalendarEvents never sends iCloud credentials to the third-party feed host', async () => {
+    const fake = await startFakeCalDav();
+    try {
+        fake.state.propfindBody = subscribedPropfind(`${fake.base}/team/schedule.ics`);
+        fake.state.feedBody = buildVCalendar('Feed Event', 'feed-uid-1');
+
+        await fetchCalendarEvents(
+            `${fake.base}/123456/calendars/sports/`,
+            'user@example.com',
+            'app-specific-password'
+        );
+
+        const propfind = fake.state.requests.find((r) => r.method === 'PROPFIND');
+        const feedGet = fake.state.requests.find((r) => r.method === 'GET');
+
+        // iCloud gets the credentials; the feed host must not.
+        assert.match(propfind.authorization ?? '', /^Basic /);
+        assert.equal(feedGet.authorization, null, 'feed request must be unauthenticated');
+    } finally {
+        await fake.close();
+    }
+});
+
+test('fetchCalendarEvents keeps using REPORT for a regular calendar', async () => {
+    const fake = await startFakeCalDav();
+    try {
+        fake.state.propfindBody = REGULAR_PROPFIND;
+        fake.state.reportBody = buildReportWithCdata(buildVCalendar('Report Event', 'report-uid-1'));
+        // Must not be touched for a non-subscribed calendar.
+        fake.state.feedBody = buildVCalendar('Feed Event', 'feed-uid-1');
+
+        const events = await fetchCalendarEvents(
+            `${fake.base}/123456/calendars/home/`,
+            'user@example.com',
+            'app-specific-password'
+        );
+
+        assert.equal(events.length, 1);
+        assert.equal(events[0].title, 'Report Event');
+
+        const methods = fake.state.requests.map((r) => r.method);
+        assert.ok(methods.includes('REPORT'), 'regular calendars still use REPORT');
+        assert.ok(!methods.includes('GET'), 'must not fetch any feed');
+    } finally {
+        await fake.close();
+    }
+});
+
+test('fetchCalendarEvents falls back to REPORT when the subscription probe fails', async () => {
+    const fake = await startFakeCalDav();
+    try {
+        // A failing probe must never break a calendar the REPORT path already handled.
+        fake.state.propfindStatus = 500;
+        fake.state.reportBody = buildReportWithCdata(buildVCalendar('Report Event', 'report-uid-1'));
+
+        const events = await fetchCalendarEvents(
+            `${fake.base}/123456/calendars/home/`,
+            'user@example.com',
+            'app-specific-password'
+        );
+
+        assert.equal(events.length, 1);
+        assert.equal(events[0].title, 'Report Event');
+        assert.ok(
+            fake.state.requests.some((r) => r.method === 'REPORT'),
+            'probe failure must fall through to REPORT'
+        );
+    } finally {
+        await fake.close();
+    }
+});
+
+test('fetchCalendarEvents reports a clear error for a subscription with no source URL', async () => {
+    const fake = await startFakeCalDav();
+    try {
+        fake.state.propfindBody = subscribedPropfind(null);
+
+        await assert.rejects(
+            () => fetchCalendarEvents(
+                `${fake.base}/123456/calendars/sports/`,
+                'user@example.com',
+                'app-specific-password'
+            ),
+            /no usable source feed URL/i
+        );
+
+        // Silently returning [] here is what made the original bug hard to spot.
+        assert.ok(!fake.state.requests.some((r) => r.method === 'GET'));
+    } finally {
+        await fake.close();
+    }
+});
+
+test('fetchCalendarEvents rejects a non-http(s) subscription source instead of fetching it', async () => {
+    const fake = await startFakeCalDav();
+    try {
+        fake.state.propfindBody = subscribedPropfind('file:///etc/passwd');
+
+        await assert.rejects(
+            () => fetchCalendarEvents(
+                `${fake.base}/123456/calendars/sports/`,
+                'user@example.com',
+                'app-specific-password'
+            ),
+            /no usable source feed URL/i
+        );
+    } finally {
+        await fake.close();
+    }
+});
+
+// ---------------------------------------------------------------------------
+// ICLOUD_XML_MESSAGE: the outbound request bodies
+// ---------------------------------------------------------------------------
+
+const STATIC_MESSAGES = [
+    'CURRENT_USER_PRINCIPAL',
+    'CALENDAR_HOME_SET',
+    'CALENDAR_LIST',
+    'COLLECTION_SOURCE',
+];
+
+test('ICLOUD_XML_MESSAGE static bodies are well-formed XML', () => {
+    for (const key of STATIC_MESSAGES) {
+        const body = ICLOUD_XML_MESSAGE[key];
+        assert.equal(typeof body, 'string', `${key} must be a string`);
+        assert.ok(body.startsWith('<?xml'), `${key} must start with an XML declaration`);
+        assert.equal(XMLValidator.validate(body), true, `${key} must be well-formed XML`);
+    }
+});
+
+test('ICLOUD_XML_MESSAGE.CALENDAR_LIST requests cs:source (regression guard)', () => {
+    // Dropping cs:source is precisely what made subscribed calendars look like
+    // empty calendars: without it the upstream feed URL is never discoverable.
+    assert.match(ICLOUD_XML_MESSAGE.CALENDAR_LIST, /<cs:source\s*\/>/);
+    assert.match(ICLOUD_XML_MESSAGE.CALENDAR_LIST, /xmlns:cs="http:\/\/calendarserver\.org\/ns\/"/);
+    // The properties the picker depends on must stay requested too.
+    assert.match(ICLOUD_XML_MESSAGE.CALENDAR_LIST, /<d:displayname\s*\/>/);
+    assert.match(ICLOUD_XML_MESSAGE.CALENDAR_LIST, /<d:resourcetype\s*\/>/);
+    assert.match(ICLOUD_XML_MESSAGE.CALENDAR_LIST, /<c:supported-calendar-component-set\s*\/>/);
+});
+
+test('ICLOUD_XML_MESSAGE.COLLECTION_SOURCE asks only what the probe needs', () => {
+    assert.match(ICLOUD_XML_MESSAGE.COLLECTION_SOURCE, /<d:resourcetype\s*\/>/);
+    assert.match(ICLOUD_XML_MESSAGE.COLLECTION_SOURCE, /<cs:source\s*\/>/);
+});
+
+test('ICLOUD_XML_MESSAGE.CALENDAR_QUERY interpolates the time-range and stays well-formed', () => {
+    const body = ICLOUD_XML_MESSAGE.CALENDAR_QUERY('20260101T000000Z', '20261231T235959Z');
+
+    assert.equal(XMLValidator.validate(body), true);
+    assert.match(body, /<c:time-range start="20260101T000000Z" end="20261231T235959Z"\s*\/>/);
+    assert.match(body, /<c:comp-filter name="VEVENT">/);
+    assert.match(body, /<c:calendar-data\s*\/>/);
+});
+
+test('ICLOUD_XML_MESSAGE is frozen so the bodies cannot be swapped at runtime', () => {
+    assert.equal(Object.isFrozen(ICLOUD_XML_MESSAGE), true);
+    assert.throws(
+        () => { 'use strict'; ICLOUD_XML_MESSAGE.COLLECTION_SOURCE = '<hacked/>'; },
+        TypeError
+    );
+});
+
+test('fetchCalendarEvents sends the calendar-query body with a time-range', async () => {
+    const fake = await startFakeCalDav();
+    try {
+        fake.state.propfindBody = REGULAR_PROPFIND;
+        fake.state.reportBody = buildReportWithCdata(buildVCalendar('Report Event', 'report-uid-1'));
+
+        await fetchCalendarEvents(
+            `${fake.base}/123456/calendars/home/`,
+            'user@example.com',
+            'app-specific-password'
+        );
+
+        const report = fake.state.requests.find((r) => r.method === 'REPORT');
+        assert.ok(report, 'a REPORT must be issued for a regular calendar');
+        assert.equal(XMLValidator.validate(report.body), true, 'REPORT body must be well-formed');
+        assert.match(report.body, /<c:calendar-query/);
+        // Basic-format UTC bounds, e.g. 20260309T094500Z
+        assert.match(report.body, /<c:time-range start="\d{8}T\d{6}Z" end="\d{8}T\d{6}Z"\s*\/>/);
+    } finally {
+        await fake.close();
+    }
 });


### PR DESCRIPTION
## Problem

A subscribed iCloud calendar — a `webcal` feed added to iCloud, such as a
TeamSnap team schedule — appears in the calendar picker and syncs with
`success`, but always imports **zero events**. The same calendar shows its
events correctly in Calendar.app.

## Root cause

An iCloud subscription is a *pointer*, not a container of event resources. Its
resourcetype is `<cs:subscribed/>` and its events live at the URL in the
`<cs:source>` property (CalendarServer extension).

`fetchCalendarEvents()` issued a `calendar-query` REPORT against the collection.
Per RFC 4791 §7.8 that report targets a calendar collection holding event
resources; against a subscription it is accepted but returns an empty
multistatus. The sync therefore recorded `success` with `0 events` and no error,
which made it look like an empty calendar rather than a bug.

`parseCalendars()` already intentionally lists subscriptions (they advertise
`VEVENT`), so they were selectable in the picker — only the fetch path was wrong.
The discovery PROPFIND also never requested `<cs:source/>`, so the feed URL was
never available, even though the `cs` namespace was already declared.

## Changes

All in `server/services/appleCalDAV.js`:

- Request `<cs:source />` during calendar discovery.
- `parseCalendars()` now reports `subscribed` and `sourceUrl` per calendar.
- `parseCollectionSource()` reads subscription details from a Depth:0 PROPFIND.
- `describeCollection()` probes a single collection before fetching.
- `fetchSubscriptionEvents()` reads the upstream ICS feed directly.
- `fetchCalendarEvents()` branches: subscriptions read their source feed,
  everything else keeps the existing REPORT path unchanged.
- `normalizeFeedUrl()` rewrites `webcal://` / `webcals://` to `https://` and
  rejects anything not `http(s)` afterwards.
- Outbound CalDAV request bodies are collected into a frozen
  `ICLOUD_XML_MESSAGE` class so the wire format lives in one place.
  `CALENDAR_QUERY` is a builder (a calendar-query must carry a concrete
  time-range); the other four are constants. This is a pure extraction — the
  generated bodies were verified **byte-identical** to the previously inlined
  literals.

## Compatibility and safety

- **Existing calendars cannot regress.** The subscription probe is wrapped in
  try/catch; any failure logs a warning and falls through to the current REPORT
  path. There is a test for this.
- **Credentials are not forwarded.** The feed fetch is deliberately
  unauthenticated: the source is a third-party host (TeamSnap, leagues, school
  districts), so the iCloud app-specific password is never sent to it. Tested.
- **No SSRF through `<cs:source>`.** Non-`http(s)` schemes are refused, so a
  malformed or hostile source property cannot trigger a `file://` read. Tested.
- **Recurrence behaviour is unchanged.** `icsToEvents()` does not expand `RRULE`,
  and neither did the REPORT path. Left as-is deliberately rather than altered
  as a side effect of this fix.
- No database migration, no schema change, no API change, and no client change.

## Testing

`cd server && npm test` — **196 pass, 0 fail** (184 before this branch).

Behavioural tests use a throwaway local `http` server rather than module mocks,
following the existing approach in `homeAssistant.test.js` and
`outboundTls.test.js`; `fetchCalendarEvents()` takes the collection URL as an
argument, so pointing it at `127.0.0.1` is enough to assert which requests it
makes:

- a subscribed calendar reads its source feed and issues **no** REPORT
- iCloud credentials are never sent to the feed host
- a regular calendar still uses REPORT and fetches no feed
- a failing probe falls back to REPORT
- a subscription with no source URL fails loudly instead of returning `[]`
- a non-`http(s)` source is refused rather than fetched
- the REPORT body carries a well-formed `calendar-query` with a time-range

Request bodies are covered too: each static body is well-formed XML,
`CALENDAR_LIST` still requests `cs:source` (dropping it is exactly what made
subscriptions look empty), and the class is frozen.

Unit tests additionally cover `webcal://`/`webcals://` rewriting, `http(s)`
passthrough, rejection of `file://`/`ftp://`/empty, subscription detection, and
`parseCalendars()` exposing `subscribed` + `sourceUrl`.

**Verified end to end** against a real iCloud-subscribed TeamSnap calendar using
`docker-compose-dev.yml`: the same source went from `success / 0 events` to
`success / 59 events in 379ms`.

## Notes for review

- Backend-only, so the light/dark theme and multi-screen-size checks in
  CONTRIBUTING.md do not apply — there are no client changes.
- Applies cleanly on top of `17d2220`; a test-merge reports no conflicts.