### PR TITLE
Let a plugin tell the host it changed core data, so widgets repaint

### DIFF
--- a/client/src/components/ChoreWidget.jsx
+++ b/client/src/components/ChoreWidget.jsx
@@ -41,6 +41,7 @@ import { getDeviceApiBase } from '../utils/deviceName.js';
 import { shouldShowChoreToday, getTodayDateString, convertDaysToCrontab, getDueDateStatus, formatDueDate } from '../utils/choreHelpers.js';
 import { filterVisibleUsers, toggleHiddenUserId, pruneHiddenUserIds } from '../utils/choreUserVisibility.js';
 import { subscribePluginEvents } from '../utils/pluginEventBridge.js';
+import { subscribePluginDataChanged } from '../utils/pluginDataBridge.js';
 import { playSound, soundUrl } from '../utils/choreSound.js';
 import { formatTime } from '../utils/dateUtils.js';
 import PrizeCelebration from './PrizeCelebration.jsx';
@@ -188,6 +189,16 @@ const ChoreWidget = ({ refreshNonce = 0 }) => {
     return () => {
       window.removeEventListener(USERS_UPDATED_EVENT, onUsersUpdated);
     };
+  }, []);
+
+  // A plugin on this display wrote chore data through the API (a routine
+  // checklist completing its chore, say). Refetch the same way the container's
+  // refresh timer does, rather than leaving a completed chore looking undone
+  // until that timer fires.
+  useEffect(() => {
+    return subscribePluginDataChanged('chores', () => {
+      fetchData();
+    });
   }, []);
 
   // Prize redemptions celebrate on every display showing the chore widget:

--- a/client/src/components/PluginWidgetWrapper.jsx
+++ b/client/src/components/PluginWidgetWrapper.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { API_BASE_URL } from '../utils/apiConfig.js';
 import { getDeviceName } from '../utils/deviceName.js';
 import { subscribePluginEvents } from '../utils/pluginEventBridge.js';
+import { acceptPluginDataMessage, emitPluginDataChanged } from '../utils/pluginDataBridge.js';
 
 const PluginWidgetWrapper = ({ filename, name, theme, transparentBackground = false, refreshNonce = 0, events = [] }) => {
   const { i18n } = useTranslation();
@@ -37,6 +38,24 @@ const PluginWidgetWrapper = ({ filename, name, theme, transparentBackground = fa
       );
     });
   }, [eventsKey, iframeOrigin]);
+
+  // The reverse direction: a plugin that wrote core data through the REST API
+  // tells the host, so widgets showing that data can refetch instead of
+  // waiting out their own refresh timer.
+  //
+  // Trust is anchored on the frame, not the payload: the message must come
+  // from THIS wrapper's iframe and from the origin its document was loaded
+  // from. Any other frame on the page — or an unknown scope — is ignored.
+  useEffect(() => {
+    const onMessage = (event) => {
+      const scope = acceptPluginDataMessage(event, iframeRef.current?.contentWindow, iframeOrigin);
+      if (!scope) return;
+      emitPluginDataChanged(scope, { filename });
+    };
+
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [iframeOrigin, filename]);
 
   return (
     <Box sx={{ width: '100%', height: '100%', overflow: 'hidden', position: 'relative' }}>

--- a/client/src/utils/pluginDataBridge.js
+++ b/client/src/utils/pluginDataBridge.js
@@ -1,0 +1,94 @@
+// Plugin -> host "I changed core data" channel.
+//
+// Plugins run in a sandboxed iframe and can write core data through the REST
+// API like any other client — completing a chore, spending clams. Nothing in
+// the host noticed when they did, so a widget showing that same data kept
+// rendering a stale copy until its own refresh timer fired (off by default,
+// and five minutes at the shortest).
+//
+// The plugin posts one message to window.parent; PluginWidgetWrapper validates
+// it came from its own iframe and re-broadcasts it as a window event that any
+// host widget can subscribe to.
+//
+// Deliberately NOT routed through the plugin event stream. The server already
+// emits chore.completed on that bus and subscribing would be fewer lines, but
+// the stream is SSE and does not reach the browser on every deployment — the
+// failure that made the issue #140 celebration invisible. Two frames on one
+// page need no network at all, so this works wherever the page itself works.
+//
+// The tradeoff that buys: this refreshes only the display that was tapped.
+// A second wall display still waits for its own timer. Fixing that genuinely
+// does need the event stream.
+
+/** postMessage `type` a plugin sends to window.parent. */
+export const PLUGIN_DATA_MESSAGE_TYPE = 'homeglow:data-changed';
+
+/** Window event the host re-broadcasts it as. */
+export const PLUGIN_DATA_CHANGED_EVENT = 'homeglow:plugin-data-changed';
+
+// What a plugin may claim to have changed. Closed set: an unknown scope is
+// dropped rather than waking every refetch in the app, so a typo in a plugin
+// is inert instead of expensive. Grow it additively as widgets learn to listen.
+export const PLUGIN_DATA_SCOPES = Object.freeze([
+  'chores',   // chore completions, schedules, clam balances
+  'users',    // profiles, avatars
+  'calendar', // events and sources
+  'prizes',   // prizes and offers
+]);
+
+const scopeSet = new Set(PLUGIN_DATA_SCOPES);
+
+export function isKnownPluginDataScope(scope) {
+  return typeof scope === 'string' && scopeSet.has(scope);
+}
+
+/**
+ * Validate a raw postMessage payload. Returns the scope, or null if this is
+ * not a well-formed data-changed message.
+ *
+ * Note this checks the payload only — proving the message came from a real
+ * plugin iframe is the wrapper's job, since only it knows which frame is which.
+ */
+export function readPluginDataMessage(data) {
+  if (!data || typeof data !== 'object') return null;
+  if (data.type !== PLUGIN_DATA_MESSAGE_TYPE) return null;
+  return isKnownPluginDataScope(data.scope) ? data.scope : null;
+}
+
+/**
+ * Decide whether a received `message` event is a genuine data-changed signal
+ * from one specific plugin iframe. Returns the scope, or null.
+ *
+ * Trust is anchored on the frame, not the payload. Any page can postMessage to
+ * the app, and a plugin is untrusted third-party HTML, so the message counts
+ * only when it came from the exact contentWindow we handed the plugin and from
+ * the origin that window's document was loaded from.
+ */
+export function acceptPluginDataMessage(event, expectedSource, expectedOrigin) {
+  if (!event || !expectedSource) return null;
+  if (event.source !== expectedSource) return null;
+  if (event.origin !== expectedOrigin) return null;
+  return readPluginDataMessage(event.data);
+}
+
+/** Broadcast to host widgets that `scope` changed. */
+export function emitPluginDataChanged(scope, detail = {}) {
+  if (!isKnownPluginDataScope(scope)) return false;
+  window.dispatchEvent(new CustomEvent(PLUGIN_DATA_CHANGED_EVENT, {
+    detail: { ...detail, scope },
+  }));
+  return true;
+}
+
+/**
+ * Subscribe to changes in one scope. Returns an unsubscribe function, so it
+ * drops straight into a useEffect.
+ */
+export function subscribePluginDataChanged(scope, handler) {
+  const listener = (event) => {
+    if (event.detail?.scope !== scope) return;
+    handler(event.detail);
+  };
+  window.addEventListener(PLUGIN_DATA_CHANGED_EVENT, listener);
+  return () => window.removeEventListener(PLUGIN_DATA_CHANGED_EVENT, listener);
+}

--- a/client/src/utils/pluginDataBridge.test.js
+++ b/client/src/utils/pluginDataBridge.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import {
+  PLUGIN_DATA_MESSAGE_TYPE,
+  PLUGIN_DATA_CHANGED_EVENT,
+  isKnownPluginDataScope,
+  readPluginDataMessage,
+  acceptPluginDataMessage,
+  emitPluginDataChanged,
+  subscribePluginDataChanged,
+} from './pluginDataBridge.js';
+
+describe('readPluginDataMessage', () => {
+  it('reads the scope from a well-formed message', () => {
+    expect(readPluginDataMessage({ type: PLUGIN_DATA_MESSAGE_TYPE, scope: 'chores' })).toBe('chores');
+  });
+
+  it('rejects anything that is not a data-changed message', () => {
+    // Plugin iframes also receive homeglow:event traffic, and a page can carry
+    // postMessage chatter from other sources entirely; none of it should be
+    // mistaken for a refresh request.
+    expect(readPluginDataMessage({ type: 'homeglow:event', event: 'chore.completed' })).toBeNull();
+    expect(readPluginDataMessage({ scope: 'chores' })).toBeNull();
+    expect(readPluginDataMessage(null)).toBeNull();
+    expect(readPluginDataMessage('chores')).toBeNull();
+    expect(readPluginDataMessage(undefined)).toBeNull();
+  });
+
+  it('rejects an unknown scope rather than passing it through', () => {
+    // A typo in a plugin must be inert, not wake every refetch in the app.
+    expect(readPluginDataMessage({ type: PLUGIN_DATA_MESSAGE_TYPE, scope: 'chore' })).toBeNull();
+    expect(readPluginDataMessage({ type: PLUGIN_DATA_MESSAGE_TYPE, scope: '*' })).toBeNull();
+    expect(readPluginDataMessage({ type: PLUGIN_DATA_MESSAGE_TYPE })).toBeNull();
+  });
+
+  it('knows the closed scope set', () => {
+    expect(isKnownPluginDataScope('chores')).toBe(true);
+    expect(isKnownPluginDataScope('everything')).toBe(false);
+  });
+});
+
+describe('acceptPluginDataMessage', () => {
+  const frame = { name: 'the plugin iframe' };
+  const other = { name: 'some other frame' };
+  const ORIGIN = 'http://homeglow.local:5001';
+  const good = { source: frame, origin: ORIGIN, data: { type: PLUGIN_DATA_MESSAGE_TYPE, scope: 'chores' } };
+
+  it('accepts a message from the expected frame and origin', () => {
+    expect(acceptPluginDataMessage(good, frame, ORIGIN)).toBe('chores');
+  });
+
+  it('rejects a message from a different frame', () => {
+    // The decisive check: any page can postMessage to the app, and an ad
+    // frame or a second plugin must not be able to drive someone else's
+    // refresh.
+    expect(acceptPluginDataMessage({ ...good, source: other }, frame, ORIGIN)).toBeNull();
+  });
+
+  it('rejects a message from a different origin', () => {
+    expect(acceptPluginDataMessage({ ...good, origin: 'https://evil.example' }, frame, ORIGIN)).toBeNull();
+  });
+
+  it('rejects when there is no iframe to compare against', () => {
+    // contentWindow is null before the iframe mounts and after it unmounts;
+    // undefined must never compare equal to an undefined event.source.
+    expect(acceptPluginDataMessage(good, null, ORIGIN)).toBeNull();
+    expect(acceptPluginDataMessage({ ...good, source: undefined }, undefined, ORIGIN)).toBeNull();
+  });
+
+  it('rejects a valid frame carrying an unusable payload', () => {
+    expect(acceptPluginDataMessage({ ...good, data: { type: 'homeglow:event' } }, frame, ORIGIN)).toBeNull();
+    expect(acceptPluginDataMessage({ ...good, data: null }, frame, ORIGIN)).toBeNull();
+  });
+});
+
+describe('emit / subscribe', () => {
+  // The suite runs in vitest's 'node' environment and jsdom is not a
+  // dependency. The bridge only needs addEventListener/removeEventListener/
+  // dispatchEvent, so Node's own EventTarget stands in for window rather than
+  // pulling in a DOM implementation for four assertions.
+  beforeAll(() => { globalThis.window = new EventTarget(); });
+  afterAll(() => { delete globalThis.window; });
+
+  const cleanups = [];
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()();
+  });
+
+  function listen(scope) {
+    const handler = vi.fn();
+    cleanups.push(subscribePluginDataChanged(scope, handler));
+    return handler;
+  }
+
+  it('delivers to subscribers of the same scope', () => {
+    const handler = listen('chores');
+    emitPluginDataChanged('chores', { filename: 'Routines.html' });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toEqual({ scope: 'chores', filename: 'Routines.html' });
+  });
+
+  it('does not deliver across scopes', () => {
+    const chores = listen('chores');
+    const calendar = listen('calendar');
+
+    emitPluginDataChanged('calendar');
+
+    expect(chores).not.toHaveBeenCalled();
+    expect(calendar).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to emit an unknown scope', () => {
+    const handler = vi.fn();
+    window.addEventListener(PLUGIN_DATA_CHANGED_EVENT, handler);
+
+    expect(emitPluginDataChanged('nonsense')).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+
+    window.removeEventListener(PLUGIN_DATA_CHANGED_EVENT, handler);
+  });
+
+  it('stops delivering once unsubscribed', () => {
+    const handler = vi.fn();
+    const stop = subscribePluginDataChanged('chores', handler);
+    stop();
+
+    emitPluginDataChanged('chores');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('supports several subscribers on one scope', () => {
+    const first = listen('chores');
+    const second = listen('chores');
+
+    emitPluginDataChanged('chores');
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/guides/plugin-development.md
+++ b/docs/guides/plugin-development.md
@@ -249,6 +249,37 @@ correct by the time `chore.allCompleted` arrives.
 live UI signals, not a durable feed — anything that must not be missed belongs
 in a **reaction** (next section) and durable state in **storage**.
 
+### Telling the host you changed core data
+
+Events flow HomeGlow → your plugin. This is the one signal that flows back.
+
+If your plugin writes core data through the REST API — completing a chore,
+adding clams — the host widgets showing that same data do not know. A chore your
+plugin just completed keeps rendering as undone until the chore widget's own
+refresh timer fires, which is **off by default** and five minutes at its
+shortest.
+
+Post one message to the parent window after the write lands:
+
+```js
+window.parent.postMessage({ type: 'homeglow:data-changed', scope: 'chores' }, '*');
+```
+
+HomeGlow re-broadcasts it to any widget listening for that scope, and the chore
+widget refetches. Valid scopes are `chores`, `users`, `calendar` and `prizes`;
+an unknown scope is dropped rather than waking every refetch in the app.
+
+Three things worth knowing:
+
+- **It is safe to send unconditionally.** A HomeGlow that predates this channel
+  ignores the message, as does a plugin page opened outside an iframe.
+- **It only refreshes the display it was sent from.** postMessage is
+  same-page, so a second wall display still waits for its own timer. This is
+  deliberate: the alternative is the SSE event stream, which does not reach the
+  browser on every deployment.
+- **It is a hint, not a write.** The host only refetches. It grants no
+  permission you did not already have by calling the API.
+
 ## 6. Reactions — server-side logic without server-side code
 
 A reaction is a bounded storage increment HomeGlow itself executes whenever an


### PR DESCRIPTION
Plugins can write core data through the REST API like any other client — a routine checklist completing its chore — but nothing in the host noticed. The chore widget kept rendering a stale copy until its own refresh timer fired, which is **off by default** and **five minutes** at its shortest ([AdminPanel.jsx:290](../blob/main/client/src/components/AdminPanel.jsx#L290)).

Events already flow host → plugin through `PluginWidgetWrapper`. This adds the one signal that flows back.

## How it works

The plugin posts one message to its parent:

```js
window.parent.postMessage({ type: 'homeglow:data-changed', scope: 'chores' }, '*');
```

`PluginWidgetWrapper` validates it and re-broadcasts it as a window event; any widget subscribed to that scope refetches. `ChoreWidget` is the first subscriber and refetches exactly as it already does for the container's refresh timer.

New file `client/src/utils/pluginDataBridge.js` owns the contract — message type, window event, the scope set, and the validation predicate.

## Trust is anchored on the frame, not the payload

Any page can `postMessage` to the app, and a plugin is untrusted third-party HTML. A message counts only when it came from **the exact `contentWindow` the wrapper handed that plugin** *and* from the origin that window's document was loaded from. Both checks live in `acceptPluginDataMessage`, which is unit-tested against a wrong frame, a wrong origin, a null frame (so `undefined === undefined` can never pass), and a valid frame carrying junk.

Scopes are a **closed set** — `chores`, `users`, `calendar`, `prizes` — so a typo in a plugin is inert rather than waking every refetch in the app.

The signal is a **hint, not a write**. The host only refetches. It grants no permission the plugin did not already have by calling the API.

## Why not the plugin event stream

The server already emits `chore.completed`, and having `ChoreWidget` subscribe would be fewer lines. But that stream is SSE, and it does not reach the browser on every deployment — the exact failure that made the #140 celebration invisible. Two frames on one page need no network at all, so this works wherever the page itself works.

The tradeoff that buys: **this refreshes only the display that was touched.** A second wall display still waits for its own timer. Fixing that genuinely does need the event stream, and this doesn't preclude it.

## Verification

Unit: 14 tests on the bridge (5 new files/tests overall, suite 155 → 160, all green). The suite runs in vitest's `node` environment and jsdom isn't a dependency, so the tests stand `window` up from Node's own `EventTarget` rather than pulling in a DOM implementation.

End to end in the real app, with the chore widget and a plugin on the same tab:

```
plugin iframes on the page: ["http://localhost:5001/widgets/Routines.html?theme=light&device=e2e-routines&lang=en"]
chore widget present: true
chore card present after create (no reload): true
chore card background BEFORE ticking: rgba(0, 0, 0, 0)
chore card background AFTER ticking:  rgba(0, 255, 0, 0.1)
REPAINTED WITHOUT RELOAD: true
```

Creating a routine made its chore appear in the chore widget with no reload, and ticking the last step turned the card from transparent to the completed tint.

Additive only: 61 insertions, 0 deletions across the two touched components plus the docs. A plugin that never posts the message behaves exactly as before.

Documented for plugin authors in `docs/guides/plugin-development.md` under section 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
