### PR TITLE
feat(calendar): Enhance support for Google event colors and labels

### DIFF
--- a/server/services/calendarSync.js
+++ b/server/services/calendarSync.js
@@ -231,7 +231,10 @@ class CalendarSyncService {
     const timeMin = new Date(now - 13 * 30 * 24 * 60 * 60 * 1000);
     const timeMax = new Date(now + 13 * 30 * 24 * 60 * 60 * 1000);
     const items = await googleCalendar.listEvents(this.db, account.id, calendarId, { timeMin, timeMax });
-    const eventColors = await googleCalendar.listEventColors(this.db, account.id);
+    const [eventColors, eventLabels] = await Promise.all([
+      googleCalendar.listEventColors(this.db, account.id),
+      googleCalendar.listEventLabels(this.db, account.id, calendarId),
+    ]);
 
     const out = [];
     for (const item of items) {
@@ -244,10 +247,16 @@ class CalendarSyncService {
       if (start.allDay) {
         endDate = new Date(endDate.getTime() - 24 * 60 * 60 * 1000);
       }
-      // colorId is only set when the event was individually recolored in
-      // Google; events on the calendar's default color omit it entirely, and
-      // those fall through to the source color at read time.
+      // Custom-label events carry only eventLabelId; default-palette events
+      // carry both. Prefer the label because its backgroundColor matches what
+      // Google's own UI shows — the legacy /colors palette still returns
+      // pre-2016 hexes (e.g. colorId 8 -> #e1e1e1 near-white, while the label
+      // is #616161 dark grey). An unresolvable label falls through so a stale
+      // label cache never strips color from an event that also has a colorId.
       const colorId = item.colorId || null;
+      const eventLabelId = item.eventLabelId || null;
+      const labelColor = eventLabelId ? (eventLabels[eventLabelId] || null) : null;
+      const paletteColor = colorId ? (eventColors[colorId] || null) : null;
       out.push({
         uid: item.id,
         title: item.summary || 'Untitled Event',
@@ -261,7 +270,8 @@ class CalendarSyncService {
           htmlLink: item.htmlLink,
           etag: item.etag,
           colorId,
-          eventColor: colorId ? (eventColors[colorId] || null) : null,
+          eventLabelId,
+          eventColor: labelColor || paletteColor || null,
         },
       });
     }

--- a/server/services/googleCalendar.js
+++ b/server/services/googleCalendar.js
@@ -60,6 +60,49 @@ async function listEventColors(db, accountId) {
     }
 }
 
+// Event labels supersede the legacy /colors palette: a label's backgroundColor
+// is the color Google's own UI shows. They live on the calendar resource, so a
+// per-(account, calendar) cache is the tightest key; a shared TTL with the
+// legacy palette keeps both refreshes on the same cadence.
+const eventLabelCache = new Map();
+
+function eventLabelCacheKey(accountId, calendarId) {
+    return `${accountId}:${calendarId}`;
+}
+
+// Maps a calendar's eventLabelId (UUID) to its backgroundColor hex. Returns an
+// empty map on failure so callers fall through to the legacy colorId path
+// rather than dropping color entirely.
+async function listEventLabels(db, accountId, calendarId) {
+    const cacheKey = eventLabelCacheKey(accountId, calendarId);
+    const cached = eventLabelCache.get(cacheKey);
+    if (cached && Date.now() - cached.fetchedAt < EVENT_COLOR_CACHE_TTL_MS) {
+        return cached.labels;
+    }
+
+    try {
+        const labels = {};
+        const data = await googleFetch(db, accountId, 'GET', `/calendars/${encodeURIComponent(calendarId)}`);
+        const list = data && data.labelProperties && data.labelProperties.eventLabels;
+        if (Array.isArray(list)) {
+            for (const label of list) {
+                if (label && label.id && label.backgroundColor) {
+                    labels[label.id] = label.backgroundColor;
+                }
+            }
+        }
+        // Same reasoning as listEventColors: only cache successful fetches.
+        // A transient failure returning an empty map, if cached, would strip
+        // label colors for the whole TTL and freeze that state into raw_data
+        // for every event synced in that window.
+        eventLabelCache.set(cacheKey, { labels, fetchedAt: Date.now() });
+        return labels;
+    } catch (error) {
+        console.error('Error fetching Google event labels:', error.message);
+        return {};
+    }
+}
+
 function parseEventDate(dt) {
     if (!dt) return null;
     if (dt.date) {
@@ -139,6 +182,7 @@ async function deleteEvent(db, accountId, calendarId, eventId) {
 module.exports = {
     listCalendars,
     listEventColors,
+    listEventLabels,
     listEvents,
     createEvent,
     updateEvent,

--- a/server/tests/calendarSync.test.js
+++ b/server/tests/calendarSync.test.js
@@ -186,29 +186,47 @@ test('getCachedEvents surfaces per-event color and leaves it null otherwise', ()
     assert.equal(mapped[1].source_color, '#123456');
 });
 
-test('fetchGoogleEvents resolves colorId to a hex via the Google palette', async () => {
+function stubGoogle({ events, colors = {}, labels = {} }) {
     const googleCalendar = require('../services/googleCalendar');
     const googleConnection = require('../services/googleConnection');
 
-    const originalGetAccount = googleConnection.getConnectedAccount;
-    const originalListEvents = googleCalendar.listEvents;
-    const originalListEventColors = googleCalendar.listEventColors;
+    const original = {
+        getConnectedAccount: googleConnection.getConnectedAccount,
+        listEvents: googleCalendar.listEvents,
+        listEventColors: googleCalendar.listEventColors,
+        listEventLabels: googleCalendar.listEventLabels,
+    };
 
     googleConnection.getConnectedAccount = () => ({ id: 'acct-1' });
-    googleCalendar.listEventColors = async () => ({ '11': '#dc2127' });
-    googleCalendar.listEvents = async () => ([
-        {
-            id: 'evt-recolored', status: 'confirmed', summary: 'Recolored',
-            start: { dateTime: '2026-05-01T13:00:00Z' },
-            end: { dateTime: '2026-05-01T14:00:00Z' },
-            colorId: '11',
-        },
-        {
-            id: 'evt-default', status: 'confirmed', summary: 'Default',
-            start: { dateTime: '2026-05-02T13:00:00Z' },
-            end: { dateTime: '2026-05-02T14:00:00Z' },
-        },
-    ]);
+    googleCalendar.listEvents = async () => events;
+    googleCalendar.listEventColors = async () => colors;
+    googleCalendar.listEventLabels = async () => labels;
+
+    return () => {
+        googleConnection.getConnectedAccount = original.getConnectedAccount;
+        googleCalendar.listEvents = original.listEvents;
+        googleCalendar.listEventColors = original.listEventColors;
+        googleCalendar.listEventLabels = original.listEventLabels;
+    };
+}
+
+test('fetchGoogleEvents resolves colorId to a hex via the Google palette', async () => {
+    const restore = stubGoogle({
+        colors: { '11': '#dc2127' },
+        events: [
+            {
+                id: 'evt-recolored', status: 'confirmed', summary: 'Recolored',
+                start: { dateTime: '2026-05-01T13:00:00Z' },
+                end: { dateTime: '2026-05-01T14:00:00Z' },
+                colorId: '11',
+            },
+            {
+                id: 'evt-default', status: 'confirmed', summary: 'Default',
+                start: { dateTime: '2026-05-02T13:00:00Z' },
+                end: { dateTime: '2026-05-02T14:00:00Z' },
+            },
+        ],
+    });
 
     try {
         const service = new CalendarSyncService({}, () => null);
@@ -220,30 +238,21 @@ test('fetchGoogleEvents resolves colorId to a hex via the Google palette', async
         assert.equal(events[1].raw.colorId, null);
         assert.equal(events[1].raw.eventColor, null);
     } finally {
-        googleConnection.getConnectedAccount = originalGetAccount;
-        googleCalendar.listEvents = originalListEvents;
-        googleCalendar.listEventColors = originalListEventColors;
+        restore();
     }
 });
 
 test('fetchGoogleEvents leaves color null when the palette is unavailable', async () => {
-    const googleCalendar = require('../services/googleCalendar');
-    const googleConnection = require('../services/googleConnection');
-
-    const originalGetAccount = googleConnection.getConnectedAccount;
-    const originalListEvents = googleCalendar.listEvents;
-    const originalListEventColors = googleCalendar.listEventColors;
-
-    googleConnection.getConnectedAccount = () => ({ id: 'acct-1' });
-    googleCalendar.listEventColors = async () => ({});
-    googleCalendar.listEvents = async () => ([
-        {
-            id: 'evt-recolored', status: 'confirmed', summary: 'Recolored',
-            start: { dateTime: '2026-05-01T13:00:00Z' },
-            end: { dateTime: '2026-05-01T14:00:00Z' },
-            colorId: '11',
-        },
-    ]);
+    const restore = stubGoogle({
+        events: [
+            {
+                id: 'evt-recolored', status: 'confirmed', summary: 'Recolored',
+                start: { dateTime: '2026-05-01T13:00:00Z' },
+                end: { dateTime: '2026-05-01T14:00:00Z' },
+                colorId: '11',
+            },
+        ],
+    });
 
     try {
         const service = new CalendarSyncService({}, () => null);
@@ -252,8 +261,122 @@ test('fetchGoogleEvents leaves color null when the palette is unavailable', asyn
         assert.equal(events[0].raw.colorId, '11');
         assert.equal(events[0].raw.eventColor, null);
     } finally {
-        googleConnection.getConnectedAccount = originalGetAccount;
-        googleCalendar.listEvents = originalListEvents;
-        googleCalendar.listEventColors = originalListEventColors;
+        restore();
+    }
+});
+
+test('fetchGoogleEvents resolves a custom-label event via its eventLabelId', async () => {
+    const restore = stubGoogle({
+        labels: { 'label-uuid-a': '#616161' },
+        events: [
+            {
+                id: 'evt-label-only', status: 'confirmed', summary: 'Custom labeled',
+                start: { dateTime: '2026-05-01T13:00:00Z' },
+                end: { dateTime: '2026-05-01T14:00:00Z' },
+                eventLabelId: 'label-uuid-a',
+            },
+        ],
+    });
+
+    try {
+        const service = new CalendarSyncService({}, () => null);
+        const events = await service.fetchGoogleEvents({ id: 1, url: 'primary' });
+
+        assert.equal(events[0].raw.colorId, null);
+        assert.equal(events[0].raw.eventLabelId, 'label-uuid-a');
+        assert.equal(events[0].raw.eventColor, '#616161');
+    } finally {
+        restore();
+    }
+});
+
+test('fetchGoogleEvents prefers the label color over the legacy palette when both are present', async () => {
+    // The regression that motivates this change: colorId 8 resolves to the
+    // pre-2016 #e1e1e1, but the current label color for the same event is
+    // #616161. If we ever regress to colorId-first, this flips back to the
+    // wrong color.
+    const restore = stubGoogle({
+        colors: { '8': '#e1e1e1' },
+        labels: { 'label-uuid-b': '#616161' },
+        events: [
+            {
+                id: 'evt-both', status: 'confirmed', summary: 'Default palette',
+                start: { dateTime: '2026-05-01T13:00:00Z' },
+                end: { dateTime: '2026-05-01T14:00:00Z' },
+                colorId: '8',
+                eventLabelId: 'label-uuid-b',
+            },
+        ],
+    });
+
+    try {
+        const service = new CalendarSyncService({}, () => null);
+        const events = await service.fetchGoogleEvents({ id: 1, url: 'primary' });
+
+        assert.equal(events[0].raw.colorId, '8');
+        assert.equal(events[0].raw.eventLabelId, 'label-uuid-b');
+        assert.equal(events[0].raw.eventColor, '#616161');
+    } finally {
+        restore();
+    }
+});
+
+test('fetchGoogleEvents leaves color null when neither colorId nor label are set', async () => {
+    const restore = stubGoogle({
+        colors: { '11': '#dc2127' },
+        labels: { 'label-uuid-c': '#616161' },
+        events: [
+            {
+                id: 'evt-none', status: 'confirmed', summary: 'Uncolored',
+                start: { dateTime: '2026-05-01T13:00:00Z' },
+                end: { dateTime: '2026-05-01T14:00:00Z' },
+            },
+        ],
+    });
+
+    try {
+        const service = new CalendarSyncService({}, () => null);
+        const events = await service.fetchGoogleEvents({ id: 1, url: 'primary' });
+
+        assert.equal(events[0].raw.colorId, null);
+        assert.equal(events[0].raw.eventLabelId, null);
+        assert.equal(events[0].raw.eventColor, null);
+    } finally {
+        restore();
+    }
+});
+
+test('fetchGoogleEvents falls through when the label id is not in the label map', async () => {
+    // Simulates a stale label cache: the event references a label we do not
+    // have a color for, but it also has a colorId. The colorId must win over
+    // dropping color entirely.
+    const restore = stubGoogle({
+        colors: { '11': '#dc2127' },
+        labels: {},
+        events: [
+            {
+                id: 'evt-unknown-label', status: 'confirmed', summary: 'Unknown label',
+                start: { dateTime: '2026-05-01T13:00:00Z' },
+                end: { dateTime: '2026-05-01T14:00:00Z' },
+                colorId: '11',
+                eventLabelId: 'label-not-in-map',
+            },
+            {
+                id: 'evt-unknown-label-only', status: 'confirmed', summary: 'Unknown label alone',
+                start: { dateTime: '2026-05-02T13:00:00Z' },
+                end: { dateTime: '2026-05-02T14:00:00Z' },
+                eventLabelId: 'label-not-in-map',
+            },
+        ],
+    });
+
+    try {
+        const service = new CalendarSyncService({}, () => null);
+        const events = await service.fetchGoogleEvents({ id: 1, url: 'primary' });
+
+        assert.equal(events[0].raw.eventColor, '#dc2127');
+        assert.equal(events[1].raw.eventColor, null);
+    } finally {
+        restore();
     }
 });


### PR DESCRIPTION
Fixes #150.

Google superseded the legacy per-event `colorId` with **event labels**. Syncing by `colorId` alone produces two user-visible faults:

- **Custom-label events carry no `colorId` at all**, so their color was dropped and the calendar fallback color was shown instead.

- **Default-palette events carry both**, but `colorId` resolves through `/colors` to a pre-2016 hex. `colorId 8` returns `#e1e1e1` (near-white) while the label says `#616161` (dark grey).

## What this does

Fetches the calendar's `labelProperties.eventLabels` alongside the existing `/colors` palette and prefers the label's `backgroundColor`, falling back to the `colorId` hex and then to `null`.

Resolution order: **label → `colorId` → source color.**

## Two things worth knowing

**No `eventLabelVersion` request parameter is needed.** The docs suggest one is required to process labels, but `eventLabelId` and `labelProperties` are both returned without it — I compared responses with and without the flag against a live account and they are identical. This PR deliberately does not set it, which also avoids the documented side effect of the flag making Google ignore `colorId`.

**The change is strictly additive.** Default-palette events return both fields and custom-label events return only the label, so preferring the label cannot remove a color any household has today. An unresolvable label id (stale cache, revoked label) falls through to `colorId` rather than blanking a color that would otherwise have resolved.

## Verification

- Backend suite green. New tests cover: label only, both fields present (asserting the **label** wins — the regression that matters), `colorId` only, neither, and an unknown label id falling through both steps.
- Verified end-to-end against a live Google account with custom labels: a custom-label event, a default-palette event and an uncolored event all render the color Google's own UI shows.

## Notes

- Server-only. `CalendarWidget`'s existing precedence (`event_color || source_color`) is unchanged.
- No schema migration — `raw_data` is JSON, and the whole source cache is deleted and re-inserted each sync, so one sync repairs existing rows.
- `listEventLabels` is cached per *(account, calendar)* because labels live on the calendar resource, not the account. A failed fetch is not cached, so a transient error retries on the next sync instead of freezing an empty map into `raw_data` for the TTL.

