### PR TITLE
Fix all-day events showing a day early, and expand recurring events

### DIFF
--- a/client/src/components/CalendarWidget.jsx
+++ b/client/src/components/CalendarWidget.jsx
@@ -9,6 +9,7 @@ import { API_BASE_URL } from '../utils/apiConfig.js';
 import { getDeviceApiBase } from '../utils/deviceName.js';
 import { getEventPillPalette, getPreferredColorMode } from '../utils/colorContrast.js';
 import { buildMergedDotColors, buildMergedDotBackground, describeMergedCalendars } from '../utils/calendarMergeColors.js';
+import { parseCalendarDate } from '../utils/calendarDates.js';
 import useIsMobile from '../hooks/useIsMobile.js';
 import { usePageVisibility } from '../hooks/useScreenActivity.js';
 import {
@@ -612,8 +613,8 @@ const CalendarWidget = ({
         const formattedEvents = response.data.map(event => ({
           id: event.id || Math.random().toString(),
           title: event.title || event.summary || 'Untitled Event',
-          start: new Date(event.start),
-          end: new Date(event.end),
+          start: parseCalendarDate(event.start, event.all_day),
+          end: parseCalendarDate(event.end, event.all_day),
           description: event.description || '',
           location: event.location || '',
           all_day: event.all_day || false,

--- a/client/src/utils/calendarDates.js
+++ b/client/src/utils/calendarDates.js
@@ -1,0 +1,20 @@
+import moment from 'moment';
+
+// All-day events are cached as UTC midnight of the calendar date they belong to:
+// "no practice on Sep 5" is a date, not an instant, so the backend deliberately
+// strips the source timezone rather than resolving it against its own (see
+// server/utils/calendarDates.js).
+//
+// Read that date back out of UTC and rebuild it as local midnight, so it stays
+// on Sep 5 on every display. Handing the stored instant straight to `new Date`
+// renders it in the browser's zone and slides the event onto the previous day
+// anywhere west of UTC — which is how an all-day marker ends up showing as
+// "11:00 PM" on the day before.
+export const parseCalendarDate = (value, allDay) => {
+  if (!allDay) return new Date(value);
+  const utc = moment.utc(value);
+  if (!utc.isValid()) return new Date(value);
+  return moment([utc.year(), utc.month(), utc.date()]).toDate();
+};
+
+export default parseCalendarDate;

--- a/client/src/utils/calendarDates.test.js
+++ b/client/src/utils/calendarDates.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import moment from 'moment';
+import { parseCalendarDate } from './calendarDates.js';
+
+describe('parseCalendarDate', () => {
+    it('keeps a timed event as the exact instant it was cached at', () => {
+        const parsed = parseCalendarDate('2026-09-04T21:00:00.000Z', false);
+        expect(parsed.toISOString()).toBe('2026-09-04T21:00:00.000Z');
+    });
+
+    // The regression: an all-day event cached as UTC midnight was handed straight
+    // to `new Date`, so a display west of UTC rendered it at 11:00 PM (or 7:00 PM,
+    // depending on the offset) on the day *before* the date the feed named.
+    it('puts an all-day event on its own calendar date, not the day before', () => {
+        const parsed = parseCalendarDate('2026-09-05T00:00:00.000Z', true);
+
+        expect(moment(parsed).format('YYYY-MM-DD')).toBe('2026-09-05');
+        expect(parsed.getHours()).toBe(0);
+        expect(parsed.getMinutes()).toBe(0);
+    });
+
+    it('resolves an all-day event to local midnight, so day math is inclusive', () => {
+        const parsed = parseCalendarDate('2026-09-05T00:00:00.000Z', true);
+        expect(moment(parsed).isSame(moment(parsed).startOf('day'))).toBe(true);
+    });
+
+    it('keeps the last day of a multi-day all-day span on its own date', () => {
+        const start = parseCalendarDate('2026-09-14T00:00:00.000Z', true);
+        const end = parseCalendarDate('2026-09-17T00:00:00.000Z', true);
+
+        expect(moment(start).format('YYYY-MM-DD')).toBe('2026-09-14');
+        expect(moment(end).format('YYYY-MM-DD')).toBe('2026-09-17');
+        expect(moment(end).diff(moment(start), 'days')).toBe(3);
+    });
+
+    it('falls back to the raw value when the date is unparseable', () => {
+        expect(Number.isNaN(parseCalendarDate('not-a-date', true).getTime())).toBe(true);
+    });
+});

--- a/server/services/appleCalDAV.js
+++ b/server/services/appleCalDAV.js
@@ -1,7 +1,8 @@
 const axios = require('axios');
-const ICAL = require('ical.js');
 const { XMLParser } = require('fast-xml-parser');
-const { DAY_MS, utcMidnight, inclusiveAllDayEnd } = require('../utils/calendarDates');
+// The ICS reader lives in utils: an iCloud calendar, a subscription's upstream
+// feed and a generic CalDAV URL all need the same one.
+const { icsToEvents, isAllDaySpan } = require('../utils/icsEvents');
 
 const CALDAV_BASE = 'https://caldav.icloud.com';
 
@@ -371,192 +372,6 @@ async function discoverAndListCalendars(appleId, appPassword) {
   return { principalUrl, homeUrl, calendars };
 }
 
-// ---------------------------------------------------------------------------
-// ICS -> HomeGlow events
-// ---------------------------------------------------------------------------
-
-// How far either side of now a series is expanded, matching the window the
-// CalDAV REPORT and the Google sync already use. A subscribed feed arrives
-// unfiltered, so this is also what keeps an open-ended RRULE bounded.
-const WINDOW_MS = 13 * 30 * 24 * 60 * 60 * 1000;
-
-// Hard stop on a single series, so a malformed or very old daily rule can never
-// spin. 10k covers ~27 years of daily occurrences.
-const MAX_OCCURRENCES_PER_SERIES = 10000;
-
-// True when a start/end pair describes whole calendar days rather than an
-// instant: either a date-only value, or midnight to midnight in the value's own
-// frame. An overnight 00:00-00:00 shift is indistinguishable from a one-day
-// all-day event in iCalendar, and is treated as all-day.
-function isAllDaySpan(start, end) {
-  if (!start) return false;
-  if (start.isDate) return true;
-  if (!end) return false;
-
-  const atMidnight = (t) => t.hour === 0 && t.minute === 0 && t.second === 0;
-  if (!atMidnight(start) || !atMidnight(end)) return false;
-
-  return end.compare(start) > 0;
-}
-
-// Resolve an occurrence's ICAL.Time pair into the instants stored in the cache.
-// All-day spans keep their wall-clock date and are anchored to UTC midnight (see
-// utils/calendarDates); timed values carry a TZID or Z and convert exactly.
-function resolveEventTimes(start, end) {
-  if (!isAllDaySpan(start, end)) {
-    return { start: start.toJSDate(), end: end.toJSDate(), allDay: false };
-  }
-
-  const startDate = utcMidnight(start.year, start.month, start.day);
-  const exclusiveEnd = end
-    ? utcMidnight(end.year, end.month, end.day)
-    : new Date(startDate.getTime() + DAY_MS);
-
-  return { start: startDate, end: inclusiveAllDayEnd(startDate, exclusiveEnd), allDay: true };
-}
-
-function buildEvent(source, times, fallbackUid, extras = {}) {
-  return {
-    uid: source.uid || fallbackUid,
-    title: source.summary || 'Untitled Event',
-    start: times.start,
-    end: times.end,
-    description: source.description || null,
-    location: source.location || null,
-    all_day: times.allDay,
-    raw: {},
-    ...extras,
-  };
-}
-
-function overlapsWindow(times, from, to) {
-  return times.end >= from && times.start <= to;
-}
-
-// Expand one series into its occurrences inside [from, to].
-//
-// ICAL's iterator walks forward from DTSTART and already skips EXDATEs, and
-// getOccurrenceDetails applies any RECURRENCE-ID override related to the master
-// — so a moved or retitled instance reports its own time and summary rather than
-// the master's.
-function expandSeries(event, from, to) {
-  const out = [];
-  const iterator = event.iterator();
-  let seen = 0;
-
-  for (let next = iterator.next(); next; next = iterator.next()) {
-    if (++seen > MAX_OCCURRENCES_PER_SERIES) break;
-
-    let details;
-    try {
-      details = event.getOccurrenceDetails(next);
-    } catch {
-      continue;
-    }
-
-    const times = resolveEventTimes(details.startDate, details.endDate);
-
-    // Occurrences are generated in order, so once one starts past the window
-    // every later one does too.
-    if (times.start > to) break;
-    if (!overlapsWindow(times, from, to)) continue;
-
-    const recurrenceId = details.recurrenceId?.toString() ?? String(times.start.getTime());
-    out.push(buildEvent(details.item ?? event, times, `apple-${recurrenceId}`, {
-      // The cache is keyed on (source, uid): every occurrence needs its own.
-      uid: `${event.uid || 'apple'}-${recurrenceId}`,
-    }));
-  }
-
-  return out;
-}
-
-// Convert a parsed ICS payload into HomeGlow event objects.
-//
-// A recurring series arrives as one master VEVENT plus a RECURRENCE-ID VEVENT
-// per modified instance; reading DTSTART off each VEVENT would show the series
-// once, at its original start (a weekly practice from last August appearing
-// only last August, and a yearly birthday stuck in 2022). So masters are
-// expanded, and overrides are attached to their master first.
-function icsToEvents(icsContent, { from, to } = {}) {
-  const comp = new ICAL.Component(ICAL.parse(icsContent));
-  const vevents = comp.getAllSubcomponents('vevent');
-
-  const now = Date.now();
-  const windowStart = from ?? new Date(now - WINDOW_MS);
-  const windowEnd = to ?? new Date(now + WINDOW_MS);
-
-  const masters = [];
-  const overrides = new Map();
-
-  for (const vevent of vevents) {
-    let event;
-    try {
-      event = new ICAL.Event(vevent);
-    } catch {
-      continue; // A malformed VEVENT must not sink the rest of the payload.
-    }
-
-    if (event.isRecurrenceException()) {
-      const uid = event.uid || '';
-      if (!overrides.has(uid)) overrides.set(uid, []);
-      overrides.get(uid).push({ vevent, event });
-    } else {
-      masters.push(event);
-    }
-  }
-
-  const events = [];
-  const claimedOverrides = new Set();
-
-  for (const event of masters) {
-    for (const override of overrides.get(event.uid) ?? []) {
-      claimedOverrides.add(override);
-      try {
-        event.relateException(override.vevent);
-      } catch {
-        // An override ICAL refuses to relate (mismatched UID/range) is emitted
-        // standalone below rather than lost.
-        claimedOverrides.delete(override);
-      }
-    }
-
-    // A VEVENT missing DTSTART throws when its times are read; one bad event in
-    // a feed must not cost us the rest of the calendar.
-    try {
-      if (event.isRecurring()) {
-        events.push(...expandSeries(event, windowStart, windowEnd));
-        continue;
-      }
-
-      const times = resolveEventTimes(event.startDate, event.endDate);
-      if (!overlapsWindow(times, windowStart, windowEnd)) continue;
-      events.push(buildEvent(event, times, `apple-${Date.now()}-${Math.random()}`));
-    } catch {
-      continue;
-    }
-  }
-
-  // Overrides with no master in this payload (or that ICAL would not relate)
-  // are still real events.
-  for (const [, list] of overrides) {
-    for (const override of list) {
-      if (claimedOverrides.has(override)) continue;
-      try {
-        const times = resolveEventTimes(override.event.startDate, override.event.endDate);
-        if (!overlapsWindow(times, windowStart, windowEnd)) continue;
-        events.push(buildEvent(override.event, times, `apple-${Date.now()}-${Math.random()}`, {
-          uid: `${override.event.uid || 'apple'}-${times.start.getTime()}`,
-        }));
-      } catch {
-        continue;
-      }
-    }
-  }
-
-  return events;
-}
-
 // Ask iCloud whether a collection is a subscription, and if so where its events
 // really live. Depth:0 so it stays a cheap single-resource lookup.
 async function describeCollection(calendarUrl, appleId, appPassword) {
@@ -671,6 +486,7 @@ module.exports = {
   parseCollectionSource,
   normalizeFeedUrl,
   extractIcsPayloads,
+  // Re-exported from utils/icsEvents so existing callers keep one import.
   icsToEvents,
   isAllDaySpan,
 };

--- a/server/services/appleCalDAV.js
+++ b/server/services/appleCalDAV.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const ICAL = require('ical.js');
 const { XMLParser } = require('fast-xml-parser');
+const { DAY_MS, utcMidnight, inclusiveAllDayEnd } = require('../utils/calendarDates');
 
 const CALDAV_BASE = 'https://caldav.icloud.com';
 
@@ -370,30 +371,187 @@ async function discoverAndListCalendars(appleId, appPassword) {
   return { principalUrl, homeUrl, calendars };
 }
 
+// ---------------------------------------------------------------------------
+// ICS -> HomeGlow events
+// ---------------------------------------------------------------------------
+
+// How far either side of now a series is expanded, matching the window the
+// CalDAV REPORT and the Google sync already use. A subscribed feed arrives
+// unfiltered, so this is also what keeps an open-ended RRULE bounded.
+const WINDOW_MS = 13 * 30 * 24 * 60 * 60 * 1000;
+
+// Hard stop on a single series, so a malformed or very old daily rule can never
+// spin. 10k covers ~27 years of daily occurrences.
+const MAX_OCCURRENCES_PER_SERIES = 10000;
+
+// True when a start/end pair describes whole calendar days rather than an
+// instant: either a date-only value, or midnight to midnight in the value's own
+// frame. An overnight 00:00-00:00 shift is indistinguishable from a one-day
+// all-day event in iCalendar, and is treated as all-day.
+function isAllDaySpan(start, end) {
+  if (!start) return false;
+  if (start.isDate) return true;
+  if (!end) return false;
+
+  const atMidnight = (t) => t.hour === 0 && t.minute === 0 && t.second === 0;
+  if (!atMidnight(start) || !atMidnight(end)) return false;
+
+  return end.compare(start) > 0;
+}
+
+// Resolve an occurrence's ICAL.Time pair into the instants stored in the cache.
+// All-day spans keep their wall-clock date and are anchored to UTC midnight (see
+// utils/calendarDates); timed values carry a TZID or Z and convert exactly.
+function resolveEventTimes(start, end) {
+  if (!isAllDaySpan(start, end)) {
+    return { start: start.toJSDate(), end: end.toJSDate(), allDay: false };
+  }
+
+  const startDate = utcMidnight(start.year, start.month, start.day);
+  const exclusiveEnd = end
+    ? utcMidnight(end.year, end.month, end.day)
+    : new Date(startDate.getTime() + DAY_MS);
+
+  return { start: startDate, end: inclusiveAllDayEnd(startDate, exclusiveEnd), allDay: true };
+}
+
+function buildEvent(source, times, fallbackUid, extras = {}) {
+  return {
+    uid: source.uid || fallbackUid,
+    title: source.summary || 'Untitled Event',
+    start: times.start,
+    end: times.end,
+    description: source.description || null,
+    location: source.location || null,
+    all_day: times.allDay,
+    raw: {},
+    ...extras,
+  };
+}
+
+function overlapsWindow(times, from, to) {
+  return times.end >= from && times.start <= to;
+}
+
+// Expand one series into its occurrences inside [from, to].
+//
+// ICAL's iterator walks forward from DTSTART and already skips EXDATEs, and
+// getOccurrenceDetails applies any RECURRENCE-ID override related to the master
+// — so a moved or retitled instance reports its own time and summary rather than
+// the master's.
+function expandSeries(event, from, to) {
+  const out = [];
+  const iterator = event.iterator();
+  let seen = 0;
+
+  for (let next = iterator.next(); next; next = iterator.next()) {
+    if (++seen > MAX_OCCURRENCES_PER_SERIES) break;
+
+    let details;
+    try {
+      details = event.getOccurrenceDetails(next);
+    } catch {
+      continue;
+    }
+
+    const times = resolveEventTimes(details.startDate, details.endDate);
+
+    // Occurrences are generated in order, so once one starts past the window
+    // every later one does too.
+    if (times.start > to) break;
+    if (!overlapsWindow(times, from, to)) continue;
+
+    const recurrenceId = details.recurrenceId?.toString() ?? String(times.start.getTime());
+    out.push(buildEvent(details.item ?? event, times, `apple-${recurrenceId}`, {
+      // The cache is keyed on (source, uid): every occurrence needs its own.
+      uid: `${event.uid || 'apple'}-${recurrenceId}`,
+    }));
+  }
+
+  return out;
+}
+
 // Convert a parsed ICS payload into HomeGlow event objects.
-function icsToEvents(icsContent) {
+//
+// A recurring series arrives as one master VEVENT plus a RECURRENCE-ID VEVENT
+// per modified instance; reading DTSTART off each VEVENT would show the series
+// once, at its original start (a weekly practice from last August appearing
+// only last August, and a yearly birthday stuck in 2022). So masters are
+// expanded, and overrides are attached to their master first.
+function icsToEvents(icsContent, { from, to } = {}) {
   const comp = new ICAL.Component(ICAL.parse(icsContent));
   const vevents = comp.getAllSubcomponents('vevent');
-  const events = [];
+
+  const now = Date.now();
+  const windowStart = from ?? new Date(now - WINDOW_MS);
+  const windowEnd = to ?? new Date(now + WINDOW_MS);
+
+  const masters = [];
+  const overrides = new Map();
 
   for (const vevent of vevents) {
-    const event = new ICAL.Event(vevent);
-    const dtstart = vevent.getFirstPropertyValue('dtstart');
-    const isAllDay = dtstart?.isDate ?? false;
-    const startDate = event.startDate.toJSDate();
-    const rawEnd = event.endDate.toJSDate();
-    const endDate = isAllDay ? subtractOneDay(rawEnd) : rawEnd;
+    let event;
+    try {
+      event = new ICAL.Event(vevent);
+    } catch {
+      continue; // A malformed VEVENT must not sink the rest of the payload.
+    }
 
-    events.push({
-      uid: event.uid || `apple-${Date.now()}-${Math.random()}`,
-      title: event.summary || 'Untitled Event',
-      start: startDate,
-      end: endDate,
-      description: event.description || null,
-      location: event.location || null,
-      all_day: isAllDay,
-      raw: {},
-    });
+    if (event.isRecurrenceException()) {
+      const uid = event.uid || '';
+      if (!overrides.has(uid)) overrides.set(uid, []);
+      overrides.get(uid).push({ vevent, event });
+    } else {
+      masters.push(event);
+    }
+  }
+
+  const events = [];
+  const claimedOverrides = new Set();
+
+  for (const event of masters) {
+    for (const override of overrides.get(event.uid) ?? []) {
+      claimedOverrides.add(override);
+      try {
+        event.relateException(override.vevent);
+      } catch {
+        // An override ICAL refuses to relate (mismatched UID/range) is emitted
+        // standalone below rather than lost.
+        claimedOverrides.delete(override);
+      }
+    }
+
+    // A VEVENT missing DTSTART throws when its times are read; one bad event in
+    // a feed must not cost us the rest of the calendar.
+    try {
+      if (event.isRecurring()) {
+        events.push(...expandSeries(event, windowStart, windowEnd));
+        continue;
+      }
+
+      const times = resolveEventTimes(event.startDate, event.endDate);
+      if (!overlapsWindow(times, windowStart, windowEnd)) continue;
+      events.push(buildEvent(event, times, `apple-${Date.now()}-${Math.random()}`));
+    } catch {
+      continue;
+    }
+  }
+
+  // Overrides with no master in this payload (or that ICAL would not relate)
+  // are still real events.
+  for (const [, list] of overrides) {
+    for (const override of list) {
+      if (claimedOverrides.has(override)) continue;
+      try {
+        const times = resolveEventTimes(override.event.startDate, override.event.endDate);
+        if (!overlapsWindow(times, windowStart, windowEnd)) continue;
+        events.push(buildEvent(override.event, times, `apple-${Date.now()}-${Math.random()}`, {
+          uid: `${override.event.uid || 'apple'}-${times.start.getTime()}`,
+        }));
+      } catch {
+        continue;
+      }
+    }
   }
 
   return events;
@@ -502,12 +660,6 @@ async function fetchCalendarEvents(calendarUrl, appleId, appPassword) {
   return events;
 }
 
-function subtractOneDay(date) {
-  const d = new Date(date);
-  d.setDate(d.getDate() - 1);
-  return d;
-}
-
 module.exports = {
   discoverAndListCalendars,
   fetchCalendarEvents,
@@ -520,4 +672,5 @@ module.exports = {
   normalizeFeedUrl,
   extractIcsPayloads,
   icsToEvents,
+  isAllDaySpan,
 };

--- a/server/services/calendarSync.js
+++ b/server/services/calendarSync.js
@@ -1,11 +1,11 @@
 const axios = require('axios');
-const ICAL = require('ical.js');
 const node_ical = require('node-ical');
 const googleConnection = require('./googleConnection');
 const googleCalendar = require('./googleCalendar');
 const appleCalDAV = require('./appleCalDAV');
 const { dedupeCalendarEvents } = require('../utils/calendarDedup');
 const { DAY_MS, utcMidnightFromLocalDate, inclusiveAllDayEnd } = require('../utils/calendarDates');
+const { icsToEvents } = require('../utils/icsEvents');
 
 class CalendarSyncService {
   constructor(db, decryptPassword) {
@@ -200,37 +200,42 @@ class CalendarSyncService {
     return out;
   }
 
+  // A "CalDAV" source is an ICS document behind HTTP basic auth: the calendar
+  // export URL of a Nextcloud/Baikal/Radicale install, or any private ICS feed.
+  // (iCloud is its own source type — it needs PROPFIND discovery, see
+  // fetchAppleCalDAVEvents.)
+  //
+  // Parsing is delegated to the shared ICS reader. This used to hand-roll it,
+  // which meant a recurring event was cached once at the date the series began,
+  // and an all-day event was anchored to the server's local midnight — landing
+  // it on the previous day on any display in another timezone.
   async fetchCalDAVEvents(source) {
     const decryptedPassword = this.decryptPassword(source.password);
     const authHeader = 'Basic ' + Buffer.from(`${source.username}:${decryptedPassword}`).toString('base64');
 
     const response = await axios.get(source.url, {
       headers: { 'Authorization': authHeader },
-      timeout: 15000
+      timeout: 15000,
+      responseType: 'text',
+      // Keep the body a raw string; the ICS reader needs the original text.
+      transformResponse: [(data) => data],
+      maxRedirects: 5,
+      validateStatus: (s) => s < 500,
     });
 
-    const icsData = response.data;
-    const jcalData = ICAL.parse(icsData);
-    const comp = new ICAL.Component(jcalData);
-    const vevents = comp.getAllSubcomponents('vevent');
+    if (response.status !== 200) {
+      throw new Error(`CalDAV request failed (HTTP ${response.status}). Check the URL and credentials.`);
+    }
 
-    return vevents.map(vevent => {
-      const event = new ICAL.Event(vevent);
-      const dtstart = vevent.getFirstPropertyValue('dtstart');
-      const isAllDay = dtstart?.isDate ?? false;
-      const rawEnd = event.endDate.toJSDate();
+    const icsData = typeof response.data === 'string' ? response.data : '';
 
-      return {
-        uid: event.uid || `${source.id}-${Date.now()}-${Math.random()}`,
-        title: event.summary || 'Untitled Event',
-        start: event.startDate.toJSDate(),
-        end: isAllDay ? this.normalizeAllDayEnd(rawEnd) : rawEnd,
-        description: event.description,
-        location: event.location,
-        all_day: isAllDay,
-        raw: {}
-      };
-    });
+    // A collection URL that needs a REPORT, or an auth redirect, answers 200 with
+    // XML or a login page. Say so, rather than surfacing an ical.js parse error.
+    if (!icsData.includes('BEGIN:VCALENDAR')) {
+      throw new Error('CalDAV URL did not return an iCalendar document. Use the calendar\'s ICS export URL.');
+    }
+
+    return icsToEvents(icsData);
   }
 
   async fetchAppleCalDAVEvents(source) {

--- a/server/services/calendarSync.js
+++ b/server/services/calendarSync.js
@@ -5,6 +5,7 @@ const googleConnection = require('./googleConnection');
 const googleCalendar = require('./googleCalendar');
 const appleCalDAV = require('./appleCalDAV');
 const { dedupeCalendarEvents } = require('../utils/calendarDedup');
+const { DAY_MS, utcMidnightFromLocalDate, inclusiveAllDayEnd } = require('../utils/calendarDates');
 
 class CalendarSyncService {
   constructor(db, decryptPassword) {
@@ -23,6 +24,18 @@ class CalendarSyncService {
     const d = new Date(end);
     d.setDate(d.getDate() - 1);
     return d;
+  }
+
+  // node-ical resolves date-only values against the server's local midnight,
+  // which bakes this machine's timezone into the cached row. Re-anchor the pair
+  // to UTC midnight of the calendar date so a display in another zone still
+  // renders the event on the day the feed named. See utils/calendarDates.
+  normalizeAllDayRange(start, end) {
+    const utcStart = utcMidnightFromLocalDate(start);
+    const exclusiveEnd = end === undefined || end === null
+      ? new Date(utcStart.getTime() + DAY_MS)
+      : utcMidnightFromLocalDate(end);
+    return { start: utcStart, end: inclusiveAllDayEnd(utcStart, exclusiveEnd) };
   }
 
   normalizeIcsTextValue(value) {
@@ -148,11 +161,14 @@ class CalendarSyncService {
       if (!instances) {
         const isAllDay = event.start?.dateOnly ?? false;
         const rawEnd = event.end;
+        const times = isAllDay
+          ? this.normalizeAllDayRange(event.start, rawEnd)
+          : { start: new Date(event.start), end: new Date(rawEnd) };
         out.push({
           uid: event.uid || `${source.id}-${Date.now()}-${Math.random()}`,
           title: this.normalizeIcsTextValue(event.summary) || 'Untitled Event',
-          start: new Date(event.start),
-          end: isAllDay ? this.normalizeAllDayEnd(rawEnd) : new Date(rawEnd),
+          start: times.start,
+          end: times.end,
           description: this.normalizeIcsTextValue(event.description),
           location: this.normalizeIcsTextValue(event.location),
           all_day: isAllDay,
@@ -163,12 +179,16 @@ class CalendarSyncService {
 
       for (const instance of instances) {
         const isAllDay = instance.start?.dateOnly ?? instance.event?.start?.dateOnly ?? false;
+        const rawStart = instance.start ?? instance.event?.start;
         const rawEnd = instance.end ?? instance.event?.end;
+        const times = isAllDay
+          ? this.normalizeAllDayRange(rawStart, rawEnd)
+          : { start: new Date(rawStart), end: new Date(rawEnd) };
         out.push({
-          uid: `${instance.uid ?? instance.event?.uid ?? source.id}-${new Date(instance.start ?? instance.event?.start).getTime()}`,
+          uid: `${instance.uid ?? instance.event?.uid ?? source.id}-${new Date(rawStart).getTime()}`,
           title: this.normalizeIcsTextValue(instance.summary ?? instance.event?.summary) || 'Untitled Event',
-          start: new Date(instance.start ?? instance.event?.start),
-          end: isAllDay ? this.normalizeAllDayEnd(rawEnd) : new Date(rawEnd),
+          start: times.start,
+          end: times.end,
           description: this.normalizeIcsTextValue(instance.description ?? instance.event?.description),
           location: this.normalizeIcsTextValue(instance.location ?? instance.event?.location),
           all_day: isAllDay,

--- a/server/tests/appleCalDAV.test.js
+++ b/server/tests/appleCalDAV.test.js
@@ -1,6 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const http = require('node:http');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { XMLValidator } = require('fast-xml-parser');
 const {
     ICLOUD_XML_MESSAGE,
@@ -11,10 +13,315 @@ const {
     normalizeFeedUrl,
     extractIcsPayloads,
     icsToEvents,
+    isAllDaySpan,
     fetchCalendarEvents,
 } = require('../services/appleCalDAV');
 
+// ---------------------------------------------------------------------------
+// All-day anchoring and recurrence expansion
+// ---------------------------------------------------------------------------
+
+const WINDOW = {
+    from: new Date('2026-08-01T00:00:00.000Z'),
+    to: new Date('2026-11-01T00:00:00.000Z'),
+};
+
+function wrapVEvents(...bodies) {
+    return [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//HomeGlow Regression Test//EN',
+        ...bodies,
+        'END:VCALENDAR',
+    ].join('\r\n');
+}
+
+const CHICAGO_VTIMEZONE = [
+    'BEGIN:VTIMEZONE',
+    'TZID:America/Chicago',
+    'BEGIN:DAYLIGHT',
+    'TZOFFSETFROM:-0600',
+    'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU',
+    'DTSTART:20070311T020000',
+    'TZNAME:CDT',
+    'TZOFFSETTO:-0500',
+    'END:DAYLIGHT',
+    'BEGIN:STANDARD',
+    'TZOFFSETFROM:-0500',
+    'RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU',
+    'DTSTART:20071104T020000',
+    'TZNAME:CST',
+    'TZOFFSETTO:-0600',
+    'END:STANDARD',
+    'END:VTIMEZONE',
+].join('\r\n');
+
+// A team feed writes its day markers as a timed midnight-to-midnight span rather
+// than VALUE=DATE. Resolving that against the server's zone put "NO PRACTICE on
+// Sep 5" at 11:00 PM on Sep 4 for any display west of the backend.
+test('icsToEvents treats a midnight-to-midnight span as an all-day event on that date', () => {
+    const events = icsToEvents(wrapVEvents(
+        'BEGIN:VEVENT',
+        'UID:day-marker',
+        'SUMMARY:NO PRACTICE',
+        'DTSTART:20260905T000000',
+        'DTEND:20260906T000000',
+        'END:VEVENT',
+    ), WINDOW);
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].all_day, true);
+    assert.equal(events[0].start.toISOString(), '2026-09-05T00:00:00.000Z');
+    assert.equal(events[0].end.toISOString(), '2026-09-05T00:00:00.000Z');
+});
+
+test('icsToEvents anchors a date-only event to UTC midnight of its date', () => {
+    const events = icsToEvents(wrapVEvents(
+        'BEGIN:VEVENT',
+        'UID:date-only',
+        'SUMMARY:No School',
+        'DTSTART;VALUE=DATE:20260905',
+        'DTEND;VALUE=DATE:20260906',
+        'END:VEVENT',
+    ), WINDOW);
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].all_day, true);
+    assert.equal(events[0].start.toISOString(), '2026-09-05T00:00:00.000Z');
+    assert.equal(events[0].end.toISOString(), '2026-09-05T00:00:00.000Z');
+});
+
+test('icsToEvents stores the last covered day for a multi-day all-day event', () => {
+    const events = icsToEvents(wrapVEvents(
+        'BEGIN:VEVENT',
+        'UID:trip',
+        'SUMMARY:Trip',
+        'DTSTART;VALUE=DATE:20260914',
+        'DTEND;VALUE=DATE:20260918',
+        'END:VEVENT',
+    ), WINDOW);
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].start.toISOString(), '2026-09-14T00:00:00.000Z');
+    // DTEND is exclusive; the cache stores the last day the event covers.
+    assert.equal(events[0].end.toISOString(), '2026-09-17T00:00:00.000Z');
+});
+
+test('icsToEvents keeps a zoned timed event as an exact instant', () => {
+    const events = icsToEvents(wrapVEvents(
+        CHICAGO_VTIMEZONE,
+        'BEGIN:VEVENT',
+        'UID:practice',
+        'SUMMARY:Practice',
+        'DTSTART;TZID=America/Chicago:20260904T160000',
+        'DTEND;TZID=America/Chicago:20260904T173000',
+        'END:VEVENT',
+    ), WINDOW);
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].all_day, false);
+    assert.equal(events[0].start.toISOString(), '2026-09-04T21:00:00.000Z');
+    assert.equal(events[0].end.toISOString(), '2026-09-04T22:30:00.000Z');
+});
+
+test('isAllDaySpan only claims whole-day spans', () => {
+    const time = (opts) => ({ hour: 0, minute: 0, second: 0, isDate: false, compare: () => 1, ...opts });
+
+    assert.equal(isAllDaySpan(time({ isDate: true }), null), true, 'date-only needs no end');
+    assert.equal(isAllDaySpan(time(), time()), true, 'midnight to a later midnight');
+    assert.equal(isAllDaySpan(time({ hour: 16 }), time()), false, 'timed start');
+    assert.equal(isAllDaySpan(time(), time({ minute: 30 })), false, 'timed end');
+    assert.equal(isAllDaySpan(time(), time({ compare: () => 0 })), false, 'zero-length midnight event');
+    assert.equal(isAllDaySpan(null, time()), false, 'no start');
+});
+
+// A recurring series arrives as one master VEVENT. Reading DTSTART off it showed
+// a weekly practice once, on the week the series began.
+test('icsToEvents expands a recurring series across the window', () => {
+    const events = icsToEvents(wrapVEvents(
+        'BEGIN:VEVENT',
+        'UID:weekly-practice',
+        'SUMMARY:Practice',
+        'DTSTART:20260901T210000Z',
+        'DTEND:20260901T223000Z',
+        'RRULE:FREQ=WEEKLY;COUNT=4',
+        'END:VEVENT',
+    ), WINDOW);
+
+    assert.deepEqual(events.map((e) => e.start.toISOString()), [
+        '2026-09-01T21:00:00.000Z',
+        '2026-09-08T21:00:00.000Z',
+        '2026-09-15T21:00:00.000Z',
+        '2026-09-22T21:00:00.000Z',
+    ]);
+    // Each occurrence needs its own uid: the cache is keyed on (source, uid).
+    assert.equal(new Set(events.map((e) => e.uid)).size, 4);
+});
+
+test('icsToEvents drops occurrences excluded by EXDATE', () => {
+    const events = icsToEvents(wrapVEvents(
+        'BEGIN:VEVENT',
+        'UID:weekly-practice',
+        'SUMMARY:Practice',
+        'DTSTART:20260901T210000Z',
+        'DTEND:20260901T223000Z',
+        'RRULE:FREQ=WEEKLY;COUNT=4',
+        'EXDATE:20260915T210000Z',
+        'END:VEVENT',
+    ), WINDOW);
+
+    assert.deepEqual(events.map((e) => e.start.toISOString()), [
+        '2026-09-01T21:00:00.000Z',
+        '2026-09-08T21:00:00.000Z',
+        '2026-09-22T21:00:00.000Z',
+    ]);
+});
+
+test('icsToEvents applies a RECURRENCE-ID override to its occurrence only', () => {
+    const events = icsToEvents(wrapVEvents(
+        'BEGIN:VEVENT',
+        'UID:weekly-practice',
+        'SUMMARY:Practice',
+        'DTSTART:20260901T210000Z',
+        'DTEND:20260901T223000Z',
+        'RRULE:FREQ=WEEKLY;COUNT=3',
+        'END:VEVENT',
+        'BEGIN:VEVENT',
+        'UID:weekly-practice',
+        'RECURRENCE-ID:20260908T210000Z',
+        'SUMMARY:Practice (moved)',
+        'DTSTART:20260908T233000Z',
+        'DTEND:20260909T010000Z',
+        'END:VEVENT',
+    ), WINDOW);
+
+    assert.equal(events.length, 3);
+    const moved = events.find((e) => e.title === 'Practice (moved)');
+    assert.ok(moved, 'the override must replace its occurrence');
+    assert.equal(moved.start.toISOString(), '2026-09-08T23:30:00.000Z');
+    // The master's own 9:00 PM slot for that date must be gone, not duplicated.
+    assert.equal(events.filter((e) => e.start.toISOString() === '2026-09-08T21:00:00.000Z').length, 0);
+});
+
+test('icsToEvents keeps an orphan RECURRENCE-ID override whose master is absent', () => {
+    const events = icsToEvents(wrapVEvents(
+        'BEGIN:VEVENT',
+        'UID:elsewhere',
+        'RECURRENCE-ID:20260908T210000Z',
+        'SUMMARY:Practice (moved)',
+        'DTSTART:20260908T233000Z',
+        'DTEND:20260909T010000Z',
+        'END:VEVENT',
+    ), WINDOW);
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].title, 'Practice (moved)');
+});
+
+test('icsToEvents bounds an open-ended series to the requested window', () => {
+    const events = icsToEvents(wrapVEvents(
+        'BEGIN:VEVENT',
+        'UID:forever',
+        'SUMMARY:Daily standup',
+        'DTSTART:20200106T150000Z',
+        'DTEND:20200106T151500Z',
+        'RRULE:FREQ=DAILY',
+        'END:VEVENT',
+    ), { from: new Date('2026-09-01T00:00:00.000Z'), to: new Date('2026-09-05T00:00:00.000Z') });
+
+    assert.deepEqual(events.map((e) => e.start.toISOString().slice(0, 10)), [
+        '2026-09-01', '2026-09-02', '2026-09-03', '2026-09-04',
+    ]);
+});
+
+test('icsToEvents survives a malformed VEVENT alongside a good one', () => {
+    const events = icsToEvents(wrapVEvents(
+        'BEGIN:VEVENT',
+        'UID:broken',
+        'SUMMARY:No dates at all',
+        'END:VEVENT',
+        'BEGIN:VEVENT',
+        'UID:fine',
+        'SUMMARY:Good event',
+        'DTSTART:20260904T210000Z',
+        'DTEND:20260904T220000Z',
+        'END:VEVENT',
+    ), WINDOW);
+
+    assert.deepEqual(events.map((e) => e.title), ['Good event']);
+});
+
+// The bug this guards was invisible in-process: the backend container ran on
+// America/New_York while the display was on America/Chicago, so the cached row
+// carried the backend's zone. Run the same payload under two very different
+// zones in real subprocesses and require identical output.
+test('icsToEvents output does not depend on the server timezone', () => {
+    const payload = wrapVEvents(
+        CHICAGO_VTIMEZONE,
+        'BEGIN:VEVENT',
+        'UID:day-marker',
+        'SUMMARY:NO PRACTICE',
+        'DTSTART:20260905T000000',
+        'DTEND:20260906T000000',
+        'END:VEVENT',
+        'BEGIN:VEVENT',
+        'UID:date-only',
+        'SUMMARY:No School',
+        'DTSTART;VALUE=DATE:20260921',
+        'DTEND;VALUE=DATE:20260922',
+        'END:VEVENT',
+        'BEGIN:VEVENT',
+        'UID:practice',
+        'SUMMARY:Practice',
+        'DTSTART;TZID=America/Chicago:20260904T160000',
+        'DTEND;TZID=America/Chicago:20260904T173000',
+        'RRULE:FREQ=WEEKLY;COUNT=3',
+        'END:VEVENT',
+    );
+
+    const script = `
+        const { icsToEvents } = require(${JSON.stringify(path.resolve(__dirname, '../services/appleCalDAV'))});
+        const events = icsToEvents(process.env.HOMEGLOW_TEST_ICS, {
+            from: new Date('2026-08-01T00:00:00.000Z'),
+            to: new Date('2026-11-01T00:00:00.000Z'),
+        });
+        process.stdout.write(JSON.stringify(events.map((e) => [
+            e.title, e.all_day, e.start.toISOString(), e.end.toISOString(),
+        ])));
+    `;
+
+    const runUnder = (tz) => {
+        const result = spawnSync(process.execPath, ['-e', script], {
+            env: { ...process.env, TZ: tz, HOMEGLOW_TEST_ICS: payload },
+            encoding: 'utf8',
+        });
+        assert.equal(result.status, 0, `child failed under TZ=${tz}: ${result.stderr}`);
+        return result.stdout;
+    };
+
+    const eastern = runUnder('America/New_York');
+    assert.equal(runUnder('Asia/Tokyo'), eastern, 'a positive-offset server must agree');
+    assert.equal(runUnder('UTC'), eastern, 'a UTC server must agree');
+
+    const parsed = JSON.parse(eastern);
+    assert.deepEqual(parsed[0], ['NO PRACTICE', true, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z']);
+    assert.deepEqual(parsed[1], ['No School', true, '2026-09-21T00:00:00.000Z', '2026-09-21T00:00:00.000Z']);
+    assert.equal(parsed.filter((e) => e[0] === 'Practice').length, 3);
+    assert.equal(parsed.find((e) => e[0] === 'Practice')[2], '2026-09-04T21:00:00.000Z');
+});
+
 // Anonymized fixtures: no real names, emails, or principal/DSID values.
+//
+// Fixture dates are relative to today on purpose: icsToEvents only keeps events
+// inside a +/-13-month window (an unfiltered subscription feed can otherwise
+// carry a decade of history), so a hardcoded date would silently age out of the
+// window and start failing these tests.
+const FIXTURE_DAY = (() => {
+    const d = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const pad = (n) => String(n).padStart(2, '0');
+    return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}`;
+})();
+
 const ANON_VCALENDAR = [
     'BEGIN:VCALENDAR',
     'CALSCALE:GREGORIAN',
@@ -24,8 +331,8 @@ const ANON_VCALENDAR = [
     'ATTENDEE;CN=Jane Doe;CUTYPE=INDIVIDUAL;EMAIL=jane@example.com',
     ' ;PARTSTAT=ACCEPTED;ROLE=CHAIR:/principal/',
     'CREATED:20251215T153939Z',
-    'DTEND;TZID=America/Chicago:20260309T104500',
-    'DTSTART;TZID=America/Chicago:20260309T094500',
+    `DTEND;TZID=America/Chicago:${FIXTURE_DAY}T104500`,
+    `DTSTART;TZID=America/Chicago:${FIXTURE_DAY}T094500`,
     'SUMMARY:Sample Event',
     'UID:00000000-0000-0000-0000-000000000000',
     'DTSTAMP:20260108T022826Z',
@@ -325,8 +632,8 @@ function buildVCalendar(summary, uid) {
         'PRODID:-//Example Inc.//Example//EN',
         'VERSION:2.0',
         'BEGIN:VEVENT',
-        'DTSTART;TZID=America/Chicago:20260309T094500',
-        'DTEND;TZID=America/Chicago:20260309T104500',
+        `DTSTART;TZID=America/Chicago:${FIXTURE_DAY}T094500`,
+        `DTEND;TZID=America/Chicago:${FIXTURE_DAY}T104500`,
         `SUMMARY:${summary}`,
         `UID:${uid}`,
         'DTSTAMP:20260108T022826Z',

--- a/server/tests/calendarSync.test.js
+++ b/server/tests/calendarSync.test.js
@@ -37,6 +37,64 @@ test('normalizeAllDayEnd subtracts one day for all-day events', () => {
     assert.equal(result.toISOString().slice(0, 10), '2026-05-01');
 });
 
+// node-ical resolves date-only values against server-local midnight. Storing
+// that instant as-is bakes the backend's timezone into the row, which is how an
+// all-day event ends up rendered at 11:00 PM the day before on a display in a
+// different zone.
+test('normalizeAllDayRange re-anchors local-midnight dates to UTC midnight', () => {
+    const service = new CalendarSyncService({}, () => null);
+
+    // Local midnight on Sep 5, whatever zone this process runs in.
+    const localStart = new Date(2026, 8, 5);
+    const localExclusiveEnd = new Date(2026, 8, 6);
+
+    const single = service.normalizeAllDayRange(localStart, localExclusiveEnd);
+    assert.equal(single.start.toISOString(), '2026-09-05T00:00:00.000Z');
+    // DTEND is exclusive; a one-day event ends on the day it starts.
+    assert.equal(single.end.toISOString(), '2026-09-05T00:00:00.000Z');
+
+    const span = service.normalizeAllDayRange(localStart, new Date(2026, 8, 8));
+    assert.equal(span.start.toISOString(), '2026-09-05T00:00:00.000Z');
+    assert.equal(span.end.toISOString(), '2026-09-07T00:00:00.000Z');
+
+    // A missing DTEND means a single day, not a zero-length event.
+    const noEnd = service.normalizeAllDayRange(localStart, null);
+    assert.equal(noEnd.start.toISOString(), '2026-09-05T00:00:00.000Z');
+    assert.equal(noEnd.end.toISOString(), '2026-09-05T00:00:00.000Z');
+});
+
+test('fetchICSEvents anchors all-day events to UTC midnight of their date', async () => {
+    const fixture = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//HomeGlow Regression Test//EN',
+        'BEGIN:VEVENT',
+        'UID:all-day@example.com',
+        'DTSTAMP:20260901T120000Z',
+        'DTSTART;VALUE=DATE:20260905',
+        'DTEND;VALUE=DATE:20260906',
+        'SUMMARY:No School',
+        'END:VEVENT',
+        'END:VCALENDAR',
+    ].join('\r\n');
+
+    const parsed = nodeIcal.sync.parseICS(fixture);
+    const service = new CalendarSyncService({}, () => null);
+    const originalFromUrl = nodeIcal.async.fromURL;
+    nodeIcal.async.fromURL = async () => parsed;
+
+    try {
+        const events = await service.fetchICSEvents({ id: 'fixture', url: 'http://example.invalid/test.ics' });
+
+        assert.equal(events.length, 1);
+        assert.equal(events[0].all_day, true);
+        assert.equal(events[0].start.toISOString(), '2026-09-05T00:00:00.000Z');
+        assert.equal(events[0].end.toISOString(), '2026-09-05T00:00:00.000Z');
+    } finally {
+        nodeIcal.async.fromURL = originalFromUrl;
+    }
+});
+
 test('fetchICSEvents normalizes SUMMARY/DESCRIPTION/LOCATION to strings', async () => {
     const fixture = buildFixtureIcs();
     const parsed = nodeIcal.sync.parseICS(fixture);

--- a/server/tests/calendarSync.test.js
+++ b/server/tests/calendarSync.test.js
@@ -1,7 +1,40 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const http = require('node:http');
 const nodeIcal = require('node-ical');
 const CalendarSyncService = require('../services/calendarSync');
+
+// Fixture dates are relative to today: icsToEvents keeps only events inside a
+// +/-13-month window, so a hardcoded date would silently age out of it.
+const FIXTURE_DATE = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+const pad = (n) => String(n).padStart(2, '0');
+const fixtureYmd = (offsetDays = 0) => {
+    const d = new Date(FIXTURE_DATE.getTime() + offsetDays * 24 * 60 * 60 * 1000);
+    return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}`;
+};
+const fixtureUtcMidnight = (offsetDays = 0) =>
+    `${fixtureYmd(offsetDays).replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3')}T00:00:00.000Z`;
+
+// Serves whatever a test puts in `state`, recording each request so the test can
+// assert what was actually sent on the wire.
+async function startFakeIcsHost() {
+    const state = { status: 200, contentType: 'text/calendar', body: '', requests: [] };
+
+    const server = http.createServer((req, res) => {
+        state.requests.push({ method: req.method, url: req.url, authorization: req.headers.authorization ?? null });
+        res.writeHead(state.status, { 'Content-Type': state.contentType });
+        res.end(state.body);
+    });
+
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+    return {
+        state,
+        url: `http://127.0.0.1:${server.address().port}/calendar.ics`,
+        close: () => new Promise((resolve) => server.close(resolve)),
+    };
+}
+
 
 function buildFixtureIcs() {
     return [
@@ -127,8 +160,133 @@ test('fetchICSEvents normalizes SUMMARY/DESCRIPTION/LOCATION to strings', async 
     }
 });
 
-test('getCachedEvents maps cached rows with source metadata', () => {
-    const sources = [
+// ---------------------------------------------------------------------------
+// Generic CalDAV sources (an ICS document behind HTTP basic auth)
+// ---------------------------------------------------------------------------
+
+test('fetchCalDAVEvents sends basic auth built from the decrypted password', async () => {
+    const host = await startFakeIcsHost();
+    host.state.body = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//HomeGlow Regression Test//EN',
+        'BEGIN:VEVENT',
+        'UID:caldav-timed@example.com',
+        `DTSTART:${fixtureYmd()}T150000Z`,
+        `DTEND:${fixtureYmd()}T160000Z`,
+        'SUMMARY:Timed event',
+        'END:VEVENT',
+        'END:VCALENDAR',
+    ].join('\r\n');
+
+    const service = new CalendarSyncService({}, () => 'plaintext-secret');
+
+    try {
+        const events = await service.fetchCalDAVEvents({
+            id: 7,
+            url: host.url,
+            username: 'user@example.com',
+            password: 'encrypted-blob',
+        });
+
+        assert.equal(events.length, 1);
+        assert.equal(events[0].title, 'Timed event');
+
+        assert.equal(host.state.requests.length, 1);
+        const expected = 'Basic ' + Buffer.from('user@example.com:plaintext-secret').toString('base64');
+        assert.equal(host.state.requests[0].authorization, expected);
+    } finally {
+        await host.close();
+    }
+});
+
+// This path hand-rolled its own ICS parse, so it carried both of the bugs the
+// shared reader fixes: a series showed up once at the date it began, and an
+// all-day event was anchored to the server's local midnight.
+test('fetchCalDAVEvents expands recurring events and anchors all-day dates', async () => {
+    const host = await startFakeIcsHost();
+    host.state.body = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//HomeGlow Regression Test//EN',
+        'BEGIN:VEVENT',
+        'UID:caldav-weekly@example.com',
+        `DTSTART:${fixtureYmd()}T150000Z`,
+        `DTEND:${fixtureYmd()}T160000Z`,
+        'SUMMARY:Weekly standup',
+        'RRULE:FREQ=WEEKLY;COUNT=3',
+        'END:VEVENT',
+        'BEGIN:VEVENT',
+        'UID:caldav-allday@example.com',
+        `DTSTART;VALUE=DATE:${fixtureYmd(1)}`,
+        `DTEND;VALUE=DATE:${fixtureYmd(2)}`,
+        'SUMMARY:Day off',
+        'END:VEVENT',
+        'END:VCALENDAR',
+    ].join('\r\n');
+
+    const service = new CalendarSyncService({}, () => 'secret');
+
+    try {
+        const events = await service.fetchCalDAVEvents({
+            id: 7, url: host.url, username: 'user', password: 'blob',
+        });
+
+        const standups = events.filter((e) => e.title === 'Weekly standup');
+        assert.equal(standups.length, 3, 'the series must be expanded, not cached once');
+        const days = standups.map((e) => e.start.getTime());
+        assert.equal(days[1] - days[0], 7 * 24 * 60 * 60 * 1000);
+        assert.equal(days[2] - days[1], 7 * 24 * 60 * 60 * 1000);
+        assert.equal(new Set(standups.map((e) => e.uid)).size, 3, 'each occurrence needs its own uid');
+
+        const dayOff = events.find((e) => e.title === 'Day off');
+        assert.ok(dayOff);
+        assert.equal(dayOff.all_day, true);
+        assert.equal(dayOff.start.toISOString(), fixtureUtcMidnight(1));
+        assert.equal(dayOff.end.toISOString(), fixtureUtcMidnight(1));
+    } finally {
+        await host.close();
+    }
+});
+
+test('fetchCalDAVEvents rejects a 200 that is not an iCalendar document', async () => {
+    const host = await startFakeIcsHost();
+    // What a collection URL needing a REPORT, or an auth redirect to a login
+    // page, actually returns. ical.js would fail on it with a parse error that
+    // says nothing useful.
+    host.state.contentType = 'text/html';
+    host.state.body = '<!doctype html><html><body>Please sign in</body></html>';
+
+    const service = new CalendarSyncService({}, () => 'secret');
+
+    try {
+        await assert.rejects(
+            () => service.fetchCalDAVEvents({ id: 7, url: host.url, username: 'user', password: 'blob' }),
+            /did not return an iCalendar document/
+        );
+    } finally {
+        await host.close();
+    }
+});
+
+test('fetchCalDAVEvents reports a failing HTTP status instead of parsing the body', async () => {
+    const host = await startFakeIcsHost();
+    host.state.status = 401;
+    host.state.body = 'Unauthorized';
+
+    const service = new CalendarSyncService({}, () => 'wrong-password');
+
+    try {
+        await assert.rejects(
+            () => service.fetchCalDAVEvents({ id: 7, url: host.url, username: 'user', password: 'blob' }),
+            /HTTP 401/
+        );
+    } finally {
+        await host.close();
+    }
+});
+
+test('getCachedEvents maps cached rows with source metadata', () => {    const sources = [
         { id: 1, name: 'Family', color: '#123456' },
     ];
 

--- a/server/utils/calendarDates.js
+++ b/server/utils/calendarDates.js
@@ -1,0 +1,46 @@
+// Shared date handling for calendar sync.
+//
+// An all-day event is a *date*, not an instant: "NO PRACTICE on Sep 5" means
+// Sep 5 wherever you are standing. The cache can only store instants, so every
+// sync path anchors all-day events to UTC midnight of the calendar date the
+// source named, and the client rebuilds them from that date. Anchoring them to
+// the server's local midnight instead (what `ICAL.Time#toJSDate()` and
+// node-ical do for date-only and floating values) bakes the server's timezone
+// into the row, so a display in any other zone renders the event on the wrong
+// day — a backend on America/New_York puts Sep 5 at 11:00 PM on Sep 4 for a
+// display on America/Chicago.
+//
+// Feeds express a day two ways, and both must land on the same anchor:
+//   DTSTART;VALUE=DATE:20260905                  (date-only)
+//   DTSTART:20260905T000000 / DTEND:20260906T000000  (midnight to midnight)
+// The second form is what SportsEngine-style team feeds emit.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// UTC midnight from calendar parts. `month` is 1-based, as it appears in ICS.
+function utcMidnight(year, month, day) {
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+// UTC midnight of the calendar date a Date lands on *in the current process's
+// timezone*. For values that were already resolved against server-local time
+// (node-ical's date-only handling), this recovers the intended calendar date.
+function utcMidnightFromLocalDate(date) {
+  const d = new Date(date);
+  return utcMidnight(d.getFullYear(), d.getMonth() + 1, d.getDate());
+}
+
+// ICS DTEND is exclusive; the cache stores the last day the event covers, which
+// is what the widget's inclusive day math expects. Never returns a value before
+// `start`, so a single-day event ends on the day it starts.
+function inclusiveAllDayEnd(start, exclusiveEnd) {
+  const end = new Date(exclusiveEnd.getTime() - DAY_MS);
+  return end.getTime() < start.getTime() ? new Date(start.getTime()) : end;
+}
+
+module.exports = {
+  DAY_MS,
+  utcMidnight,
+  utcMidnightFromLocalDate,
+  inclusiveAllDayEnd,
+};

--- a/server/utils/icsEvents.js
+++ b/server/utils/icsEvents.js
@@ -1,0 +1,200 @@
+// Reading an iCalendar (ICS) document into HomeGlow events.
+//
+// Shared by every source that speaks ICS: an iCloud CalDAV calendar, an iCloud
+// subscription's upstream feed, and a generic CalDAV/authenticated-ICS URL. It
+// is deliberately not Apple-specific — keeping one reader is what stops each
+// source from growing its own subtly different notion of "all day" and its own
+// answer to "does this series repeat?".
+
+const ICAL = require('ical.js');
+const { DAY_MS, utcMidnight, inclusiveAllDayEnd } = require('./calendarDates');
+
+
+// How far either side of now a series is expanded, matching the window the
+// CalDAV REPORT and the Google sync already use. A subscribed feed arrives
+// unfiltered, so this is also what keeps an open-ended RRULE bounded.
+const WINDOW_MS = 13 * 30 * 24 * 60 * 60 * 1000;
+
+// Hard stop on a single series, so a malformed or very old daily rule can never
+// spin. 10k covers ~27 years of daily occurrences.
+const MAX_OCCURRENCES_PER_SERIES = 10000;
+
+// True when a start/end pair describes whole calendar days rather than an
+// instant: either a date-only value, or midnight to midnight in the value's own
+// frame. An overnight 00:00-00:00 shift is indistinguishable from a one-day
+// all-day event in iCalendar, and is treated as all-day.
+function isAllDaySpan(start, end) {
+  if (!start) return false;
+  if (start.isDate) return true;
+  if (!end) return false;
+
+  const atMidnight = (t) => t.hour === 0 && t.minute === 0 && t.second === 0;
+  if (!atMidnight(start) || !atMidnight(end)) return false;
+
+  return end.compare(start) > 0;
+}
+
+// Resolve an occurrence's ICAL.Time pair into the instants stored in the cache.
+// All-day spans keep their wall-clock date and are anchored to UTC midnight (see
+// utils/calendarDates); timed values carry a TZID or Z and convert exactly.
+function resolveEventTimes(start, end) {
+  if (!isAllDaySpan(start, end)) {
+    return { start: start.toJSDate(), end: end.toJSDate(), allDay: false };
+  }
+
+  const startDate = utcMidnight(start.year, start.month, start.day);
+  const exclusiveEnd = end
+    ? utcMidnight(end.year, end.month, end.day)
+    : new Date(startDate.getTime() + DAY_MS);
+
+  return { start: startDate, end: inclusiveAllDayEnd(startDate, exclusiveEnd), allDay: true };
+}
+
+function buildEvent(source, times, fallbackUid, extras = {}) {
+  return {
+    uid: source.uid || fallbackUid,
+    title: source.summary || 'Untitled Event',
+    start: times.start,
+    end: times.end,
+    description: source.description || null,
+    location: source.location || null,
+    all_day: times.allDay,
+    raw: {},
+    ...extras,
+  };
+}
+
+function overlapsWindow(times, from, to) {
+  return times.end >= from && times.start <= to;
+}
+
+// Expand one series into its occurrences inside [from, to].
+//
+// ICAL's iterator walks forward from DTSTART and already skips EXDATEs, and
+// getOccurrenceDetails applies any RECURRENCE-ID override related to the master
+// — so a moved or retitled instance reports its own time and summary rather than
+// the master's.
+function expandSeries(event, from, to) {
+  const out = [];
+  const iterator = event.iterator();
+  let seen = 0;
+
+  for (let next = iterator.next(); next; next = iterator.next()) {
+    if (++seen > MAX_OCCURRENCES_PER_SERIES) break;
+
+    let details;
+    try {
+      details = event.getOccurrenceDetails(next);
+    } catch {
+      continue;
+    }
+
+    const times = resolveEventTimes(details.startDate, details.endDate);
+
+    // Occurrences are generated in order, so once one starts past the window
+    // every later one does too.
+    if (times.start > to) break;
+    if (!overlapsWindow(times, from, to)) continue;
+
+    const recurrenceId = details.recurrenceId?.toString() ?? String(times.start.getTime());
+    out.push(buildEvent(details.item ?? event, times, `apple-${recurrenceId}`, {
+      // The cache is keyed on (source, uid): every occurrence needs its own.
+      uid: `${event.uid || 'apple'}-${recurrenceId}`,
+    }));
+  }
+
+  return out;
+}
+
+// Convert a parsed ICS payload into HomeGlow event objects.
+//
+// A recurring series arrives as one master VEVENT plus a RECURRENCE-ID VEVENT
+// per modified instance; reading DTSTART off each VEVENT would show the series
+// once, at its original start (a weekly practice from last August appearing
+// only last August, and a yearly birthday stuck in 2022). So masters are
+// expanded, and overrides are attached to their master first.
+function icsToEvents(icsContent, { from, to } = {}) {
+  const comp = new ICAL.Component(ICAL.parse(icsContent));
+  const vevents = comp.getAllSubcomponents('vevent');
+
+  const now = Date.now();
+  const windowStart = from ?? new Date(now - WINDOW_MS);
+  const windowEnd = to ?? new Date(now + WINDOW_MS);
+
+  const masters = [];
+  const overrides = new Map();
+
+  for (const vevent of vevents) {
+    let event;
+    try {
+      event = new ICAL.Event(vevent);
+    } catch {
+      continue; // A malformed VEVENT must not sink the rest of the payload.
+    }
+
+    if (event.isRecurrenceException()) {
+      const uid = event.uid || '';
+      if (!overrides.has(uid)) overrides.set(uid, []);
+      overrides.get(uid).push({ vevent, event });
+    } else {
+      masters.push(event);
+    }
+  }
+
+  const events = [];
+  const claimedOverrides = new Set();
+
+  for (const event of masters) {
+    for (const override of overrides.get(event.uid) ?? []) {
+      claimedOverrides.add(override);
+      try {
+        event.relateException(override.vevent);
+      } catch {
+        // An override ICAL refuses to relate (mismatched UID/range) is emitted
+        // standalone below rather than lost.
+        claimedOverrides.delete(override);
+      }
+    }
+
+    // A VEVENT missing DTSTART throws when its times are read; one bad event in
+    // a feed must not cost us the rest of the calendar.
+    try {
+      if (event.isRecurring()) {
+        events.push(...expandSeries(event, windowStart, windowEnd));
+        continue;
+      }
+
+      const times = resolveEventTimes(event.startDate, event.endDate);
+      if (!overlapsWindow(times, windowStart, windowEnd)) continue;
+      events.push(buildEvent(event, times, `apple-${Date.now()}-${Math.random()}`));
+    } catch {
+      continue;
+    }
+  }
+
+  // Overrides with no master in this payload (or that ICAL would not relate)
+  // are still real events.
+  for (const [, list] of overrides) {
+    for (const override of list) {
+      if (claimedOverrides.has(override)) continue;
+      try {
+        const times = resolveEventTimes(override.event.startDate, override.event.endDate);
+        if (!overlapsWindow(times, windowStart, windowEnd)) continue;
+        events.push(buildEvent(override.event, times, `apple-${Date.now()}-${Math.random()}`, {
+          uid: `${override.event.uid || 'apple'}-${times.start.getTime()}`,
+        }));
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return events;
+}
+
+
+module.exports = {
+  icsToEvents,
+  // Exported for unit testing.
+  isAllDaySpan,
+};


### PR DESCRIPTION
## The problem

An all-day event is a date, not an instant. Both sync paths resolved date-only
values against the **server's** local midnight and cached the resulting instant,
which baked the backend's timezone into the row. A backend on `America/New_York`
therefore handed a display on `America/Chicago` an all-day marker that rendered
at 11:00 PM on the *previous* day:

```
NO PRACTICE   cached: 2026-09-05T04:00:00Z   all_day: false
              shown:  Fri Sep 4, 11:00 PM
```

Two things compounded it:

- School-sports feeds (SportsEngine and friends) write their day markers as a
  timed midnight-to-midnight span rather than `VALUE=DATE`, so `all_day` was
  false and the widget drew a clock time instead of an all-day banner.
- `icsToEvents` read `DTSTART` off each VEVENT without expanding `RRULE`, so a
  recurring series appeared once, at the date it began — a yearly birthday
  stranded in 2022, a weekly practice only in the week it started, and a shared
  iCloud calendar syncing 17 events across two years.

## The change

- All-day events are anchored to **UTC midnight of the calendar date the source
  named**, on every sync path (`server/utils/calendarDates.js`). Google's sync
  already did this; Apple and ICS now match. The widget rebuilds them as local
  midnight from that date, so they hold their day on any display.
- A midnight-to-midnight span is recognised as all-day. An overnight `00:00`
  to `00:00` shift is indistinguishable from a one-day all-day event in
  iCalendar, and is treated as all-day.
- Recurring series are expanded over the same ±13-month window the rest of the
  sync uses, honouring `EXDATE` and applying `RECURRENCE-ID` overrides to their
  own occurrence only, with an iteration cap so an open-ended daily `RRULE`
  cannot spin.
- The ICS reader moved to `server/utils/icsEvents.js`: an iCloud calendar, a
  subscription's upstream feed and a generic CalDAV URL all need the same one,
  and it was only in `appleCalDAV.js` because that is where it was written.
  `appleCalDAV` re-exports `icsToEvents` so callers keep a single import.
- The generic `CalDAV` source type now uses that reader instead of its own
  hand-rolled parse, so it loses the same two bugs, and reports a non-200 or a
  non-iCalendar body (a login page, or the XML a collection URL returns when it
  wanted a `REPORT`) instead of surfacing an `ical.js` parse error.

Also fixes, incidentally: the event edit dialog showed the previous day for
Google all-day events, and cross-calendar dedup can now match an all-day event
between a Google and an Apple calendar, since both anchor it identically.

## Testing

Server 234/234, client 165/165, `npm run build` clean.

The key test runs the same ICS payload in three subprocesses under
`America/New_York`, `Asia/Tokyo` and `UTC` and requires byte-identical output —
which the old code could never do. Alongside it: date-only and
midnight-to-midnight anchoring, multi-day spans, `EXDATE`, `RECURRENCE-ID`
overrides (including an orphan whose master is absent), window bounding of an
open-ended series, and a malformed VEVENT not sinking the rest of the payload.

The CalDAV path is covered end-to-end against a local ICS host: the basic-auth
header is asserted from what the server actually received, a series is expanded,
an all-day date is anchored, and both failure shapes report clearly.

Existing `appleCalDAV` fixtures were pinned to March 2026; they are now relative
to today, since the ±13-month window would otherwise age them out and start
failing the suite.

## Notes

- Verified against a live install whose backend runs `America/New_York` with a
  Central display — the reported symptom. Expect noticeably more (correct)
  events after the first sync, since recurring series were previously collapsed
  to one occurrence.
- Setting `TZ` correctly on the backend is still worth doing: all-day events no
  longer care, but a feed that sends a *timed* value with no timezone at all is
  still resolved against the server's clock.
- The generic CalDAV path remains an authenticated `GET` of an ICS document, not
  a real `REPORT`. That works for export URLs (Nextcloud, Baikal) but not for a
  collection URL that requires a `REPORT` — now a clear error rather than a
  parse failure.
