### PR TITLE
Offer the photo slideshow screensaver for any configured photo source

### DIFF
--- a/client/src/components/AdminPanel.jsx
+++ b/client/src/components/AdminPanel.jsx
@@ -158,6 +158,11 @@ const buildTagUrl = (repository, tagName) => {
 };
 
 
+// GooglePhotos and HomeGlowPhotos item counts come from a local DB read and are trustworthy.
+// Immich item counts are NOT — the server catches per-source Immich errors and returns [] with
+// 200, so a network outage is indistinguishable from an empty library at the client.
+const DB_BACKED_PHOTO_TYPES = ['GooglePhotos', 'HomeGlowPhotos'];
+
 const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
   const { t, i18n } = useTranslation(['admin', 'common']);
   const isMobile = useIsMobile();
@@ -235,7 +240,8 @@ const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
   // stored values (a stored default would pin the household against future
   // manifest default changes).
   const [pluginDeclaredDirty, setPluginDeclaredDirty] = useState({});
-  const [photoSources, setPhotoSources] = useState([]);
+  const [photoSources, setPhotoSources] = useState(null); // null = not yet loaded
+  const [photoItemCount, setPhotoItemCount] = useState(null); // null = unknown
   const [screensaverSettings, setScreensaverSettings] = useState(readLocalScreensaverSettings);
   const [vacationModeSettings, setVacationModeSettings] = useState(readLocalVacationModeSettings);
   const [autoDarkModeSettings, setAutoDarkModeSettings] = useState(readLocalAutoDarkModeSettings);
@@ -317,7 +323,7 @@ const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
       fetchUploadedWidgets();
       fetchTabs();
       fetchWidgetAssignments();
-      fetchPhotoSources();
+      fetchPhotoData();
       fetchDevices();
     }
   }, [isAuthenticated]);
@@ -344,13 +350,29 @@ const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
     }
   };
 
-  const fetchPhotoSources = async () => {
+  const fetchPhotoData = async () => {
+    let sources;
     try {
       const response = await axios.get(`${API_BASE_URL}/api/photo-sources`);
-      setPhotoSources(Array.isArray(response.data) ? response.data : []);
+      sources = Array.isArray(response.data) ? response.data : [];
     } catch (error) {
       console.error('Error fetching photo sources:', error);
-      setPhotoSources([]);
+      return; // leave photoSources null — gate won't assert anything while unknown
+    }
+    setPhotoSources(sources);
+
+    // Immich is gated on source existence, not item count — see DB_BACKED_PHOTO_TYPES comment.
+    // Skip the extra request entirely for households that have an Immich source configured.
+    if (sources.some(s => s.type === 'Immich' && s.enabled === 1)) {
+      return;
+    }
+
+    try {
+      const response = await axios.get(`${API_BASE_URL}/api/photo-items`);
+      setPhotoItemCount(Array.isArray(response.data) ? response.data.length : 0);
+    } catch (error) {
+      console.error('Error fetching photo items:', error);
+      // null = unknown; gate falls back to source-only check rather than disabling
     }
   };
 
@@ -1488,7 +1510,19 @@ const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
     });
   };
 
-  const hasImmichConfigured = photoSources.some(source => source.type === 'Immich' && source.enabled === 1);
+  const sourcesLoaded = photoSources !== null;
+  const hasImmichSource = sourcesLoaded && photoSources.some(s => s.type === 'Immich' && s.enabled === 1);
+  const hasNonImmichPhotoSource = sourcesLoaded && photoSources.some(s => DB_BACKED_PHOTO_TYPES.includes(s.type) && s.enabled === 1);
+  // For non-Immich types the item count is a trustworthy DB read.
+  // When null (HomeGlow server unreachable), fall back to source-only check.
+  const nonImmichCanSupplyItems = hasNonImmichPhotoSource && (photoItemCount === null || photoItemCount > 0);
+  const canUsePhotoSlideshow = sourcesLoaded && (hasImmichSource || nonImmichCanSupplyItems);
+  // null while sources are still loading — avoids asserting "no source" before data arrives.
+  const photoDisabledReason = !sourcesLoaded
+    ? null
+    : !(hasImmichSource || hasNonImmichPhotoSource)
+      ? t('admin:screensaver.photoNoSource')
+      : t('admin:screensaver.photoNoItems');
   const hasTabsCreated = tabs.length > 0;
 
   const handleWidgetToggle = (widget, field) => {
@@ -2919,12 +2953,12 @@ const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
                 </Tooltip>
 
                 <Tooltip
-                  title={!hasImmichConfigured ? "Configure Immich in the Photos widget settings to use this mode" : ""}
+                  title={!canUsePhotoSlideshow ? (photoDisabledReason || '') : ""}
                   placement="right"
                 >
                   <FormControlLabel
                     value="photos"
-                    control={<Radio disabled={!hasImmichConfigured} />}
+                    control={<Radio disabled={!canUsePhotoSlideshow} />}
                     label={
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <PhotoLibrary fontSize="small" />
@@ -2933,28 +2967,28 @@ const AdminPanel = ({ setWidgetSettings, onPluginsChanged, onTabsChanged }) => {
                             variant="body2"
                             sx={{
                               fontWeight: 'bold',
-                              color: !hasImmichConfigured ? 'text.disabled' : 'inherit'
+                              color: !canUsePhotoSlideshow ? 'text.disabled' : 'inherit'
                             }}
                           >
-                            {t('admin:screensaver.immichSlideshow')}
+                            {t('admin:screensaver.photoSlideshow')}
                           </Typography>
                           <Typography
                             variant="caption"
-                            color={!hasImmichConfigured ? 'text.disabled' : 'text.secondary'}
+                            color={!canUsePhotoSlideshow ? 'text.disabled' : 'text.secondary'}
                           >
-                            {hasImmichConfigured
-                              ? 'Display photos from your Immich library'
-                              : 'Immich not configured'}
+                            {canUsePhotoSlideshow
+                              ? t('admin:screensaver.photoSlideshowHelp')
+                              : (photoDisabledReason || '')}
                           </Typography>
                         </Box>
-                        {!hasImmichConfigured && (
-                          <Tooltip title={t('admin:screensaver.immichDisabled')}>
+                        {!canUsePhotoSlideshow && photoDisabledReason && (
+                          <Tooltip title={photoDisabledReason}>
                             <Info fontSize="small" color="disabled" />
                           </Tooltip>
                         )}
                       </Box>
                     }
-                    sx={{ opacity: !hasImmichConfigured ? 0.6 : 1 }}
+                    sx={{ opacity: !canUsePhotoSlideshow ? 0.6 : 1 }}
                   />
                 </Tooltip>
               </RadioGroup>

--- a/client/src/i18n/locales/en/admin.json
+++ b/client/src/i18n/locales/en/admin.json
@@ -204,8 +204,10 @@
     "cycleTabs": "Cycle Through Tabs",
     "cycleTabsHelp": "Automatically switch between {{count}} tabs",
     "cycleTabsDisabled": "Create tabs in the Tab Bar to enable this feature",
-    "immichSlideshow": "Immich Photo Slideshow",
-    "immichDisabled": "Configure an Immich photo source in the Photos widget to enable this feature",
+    "photoSlideshow": "Photo Slideshow",
+    "photoSlideshowHelp": "Display photos from your configured sources",
+    "photoNoSource": "Configure a photo source in the Photos widget to enable this feature",
+    "photoNoItems": "Add photos to your configured source to enable this feature",
     "photoInterval": "Photo Slideshow Interval",
     "tabInterval": "Tab Cycle Interval",
     "save": "Save Screensaver Settings"

--- a/client/src/i18n/locales/es/admin.json
+++ b/client/src/i18n/locales/es/admin.json
@@ -204,8 +204,10 @@
     "cycleTabs": "Pasar por las pestañas",
     "cycleTabsHelp": "Cambiar automáticamente entre {{count}} pestañas",
     "cycleTabsDisabled": "Crea pestañas en la barra para poder usar esta función",
-    "immichSlideshow": "Pase de fotos de Immich",
-    "immichDisabled": "Configura una fuente de fotos de Immich en el widget de fotos para poder usar esta función",
+    "photoSlideshow": "Pase de fotos",
+    "photoSlideshowHelp": "Mostrar fotos de tus fuentes configuradas",
+    "photoNoSource": "Configura una fuente de fotos en el widget de fotos para poder usar esta función",
+    "photoNoItems": "Añade fotos a tu fuente configurada para poder usar esta función",
     "photoInterval": "Intervalo del pase de fotos",
     "tabInterval": "Intervalo entre pestañas",
     "save": "Guardar los ajustes del salvapantallas"


### PR DESCRIPTION
### What this does

The screensaver's photo slideshow mode is currently selectable only when an **Immich** source is
configured:

```js
// client/src/components/AdminPanel.jsx
const hasImmichConfigured = photoSources.some(source => source.type === 'Immich' && source.enabled === 1);
```

But the rendering path is already source-agnostic. `ScreenSaver.jsx` fetches `GET /api/photo-items`,
and that endpoint iterates every enabled source and handles `Immich`, `GooglePhotos` **and**
`HomeGlowPhotos`. So a household using Google Photos or HomeGlow's own uploads cannot select a mode
that would already work for them — the Admin Panel gate is the only thing in the way.

This broadens the gate to all three source types and re-labels the mode generically. No server
change, no schema change, no new endpoint.

### Availability, not just configuration

A source that is configured but has no photos would give the user a blank screensaver with no
explanation, which is worse than the option being greyed out. So the gate also requires at least one
item to be available.

That introduces a subtlety worth stating plainly, because it shaped the implementation:

**`/api/photo-items` cannot report an Immich failure.** Its per-source handler catches, logs and
returns `[]`, and the outer handler responds `200` with the flattened array. An unreachable Immich is
therefore indistinguishable from an empty Immich at the client. Measured against a source pointed at
an unroutable address:

```
GET /api/photo-items -> HTTP 200 in 15.1s, Immich contributed 0 items
```

Gating Immich on that count would disable the mode during an outage and tell the user to add photos
to a library that is merely offline — a regression against today's behaviour.

So the gate is deliberately asymmetric:

- **Immich** — gated on the source existing, exactly as today. Its item count is never consulted.
- **GooglePhotos / HomeGlowPhotos** — gated on item count, which for these types is a local database
  read and therefore trustworthy.

A comment at `DB_BACKED_PHOTO_TYPES` records the reasoning, since collapsing this back into a uniform
count check would silently reintroduce the outage regression.

This also means the extra request is **skipped entirely** when an Immich source is present, as the
result cannot change the outcome — Immich households pay nothing, and nobody waits on a 15-second
timeout to populate a radio button.

### Other changes

- `photoSources` now starts as `null` rather than `[]`, so the panel no longer asserts "no photo
  source configured" while that request is still in flight.
- The disabled-state text distinguishes "no source configured" from "source configured but no photos",
  which are different user actions.
- Two previously untranslated inline English strings are extracted into i18n keys.
  `immichSlideshow` → `photoSlideshow` and `immichDisabled` → `photoNoSource`, with
  `photoSlideshowHelp` and `photoNoItems` added. Both `en` and `es` updated.

### Testing

`npm --prefix client test` (160 passed), `npm run build`, and `npm run check:i18n` (733/733 en/es
parity) all pass.

Exercised by hand on a live instance running this commit, with the backend on upstream `main`:

| scenario | result |
|---|---|
| Google Photos source with photos, no Immich | mode selectable, slideshow shows the photos |
| source configured, zero photos | disabled, "Add photos to your configured source" |
| Immich configured but unreachable | **stays selectable**, no item request made, no stall |
| no enabled photo source | disabled, "Configure a photo source in the Photos widget" |

### Known gaps

`photoSources` is fetched once when the Admin Panel authenticates and is not refreshed afterwards, so
adding a photo source in the same session needs a reload before the radio updates. That is
pre-existing behaviour and is left untouched here rather than widening this change.
