### PR TITLE
fix(nginx): route /plugin-sdk/ and /index.css to the backend

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -60,6 +60,28 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    # Plugin SDK, served by the backend. `^~` is required: regex locations are
+    # matched before prefix locations, so the static-asset regex below would
+    # otherwise capture /plugin-sdk/v1.js and try_files it to a 404.
+    location ^~ /plugin-sdk/ {
+        proxy_pass http://${BACKEND_SERVICE}:${BACKEND_PORT}/plugin-sdk/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Theme stylesheet plugins link as /index.css (see the plugin development
+    # guide). Exact match, so it wins over the static-asset regex without
+    # shadowing the hashed stylesheets under /assets/.
+    location = /index.css {
+        proxy_pass http://${BACKEND_SERVICE}:${BACKEND_PORT}/index.css;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     # Cache static assets from build - but NOT from /Uploads/ or /uploads/
     location ~* ^/(?!Uploads|uploads|widgets).*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         try_files $uri =404;


### PR DESCRIPTION
Fixes #154.

nginx has no `location` for `/plugin-sdk/` or `/index.css`, so both are captured by the static-asset regex and returned as 404. In any deployment where nginx serves the frontend, a plugin iframe cannot load the SDK or the theme variables.

Two location blocks, placed before the static-asset regex:

- `location ^~ /plugin-sdk/` — proxied to the backend, which already serves `/plugin-sdk/v1.js`.
- `location = /index.css` — proxied to the backend, which already serves it.

`^~` and `=` are load-bearing rather than stylistic. nginx matches regex locations before prefix locations, so a plain `location /plugin-sdk/` would still lose to the `.js|.css` static-asset regex and 404 exactly as before. `= /index.css` wins as an exact match without shadowing the hashed stylesheets under `/assets/`. Both carry the same proxy headers as the existing `/widgets/` block.

No behaviour changes outside those two paths.

## Verified

On a container deployment before and after, through nginx:

| Path | Before | After |
|---|---|---|
| `/plugin-sdk/v1.js` | 404 | 200 `application/javascript` |
| `/index.css` | 404 | 200 `text/css` |

The served SDK is byte-identical to `server/plugin-sdk/v1.js` at this commit (sha256 comparison, not a status code).

Unchanged after the patch: `/api/`, `/uploads/`, `/Uploads/`, `/widgets/`, `= /index.html`, the SPA fallback, and hashed assets under `/assets/` (still `Cache-Control: max-age=31536000, public, immutable`).

End to end, a plugin declaring `apiVersion: "v1"` now reaches `window.HomeGlow.pluginId`, stores server-side (confirmed across two browsers), and picks up the theme variables from `/index.css`.

`nginx -t` passes.

## Note for anyone deploying this

Plugins already installed that load the SDK have been silently falling back to browser-local storage, because they guard on `window.HomeGlow`. Once the SDK loads they read server-side settings, which will be empty where a display currently shows local data — so expect a one-time reset of those plugins' settings rather than a migration of them.

I have not included any migration code or docs for that stranded localStorage data. Happy to follow up with it in a separate PR (or to add it here) if you would like it — it would have to live in each affected plugin, since only code running in that browser can read its `localStorage`.
